### PR TITLE
Remove invalid simplicial layer import

### DIFF
--- a/energy_transformer/layers/__init__.py
+++ b/energy_transformer/layers/__init__.py
@@ -3,11 +3,9 @@
 from .attention import MultiHeadEnergyAttention
 from .hopfield import HopfieldNetwork
 from .layer_norm import LayerNorm
-from .simplicial import SimplicialHopfieldNetwork
 
 __all__ = [
     "MultiHeadEnergyAttention",
     "LayerNorm",
     "HopfieldNetwork",
-    "SimplicialHopfieldNetwork",
 ]


### PR DESCRIPTION
## Summary
- clean up `energy_transformer.layers` by dropping the obsolete `SimplicialHopfieldNetwork` import and `__all__` entry

## Testing
- `python - <<'PY'
import importlib
try:
    importlib.import_module('energy_transformer.layers')
    print('SUCCESS')
except Exception as e:
    print('IMPORT FAILED:', e)
PY` *(fails: No module named 'torch')*