### PR TITLE
Fix PosEmbed initialization

### DIFF
--- a/energy_transformer/layers/embeddings.py
+++ b/energy_transformer/layers/embeddings.py
@@ -166,6 +166,7 @@ class PositionalEmbedding2D(nn.Module):  # type: ignore
         num_patches: int,
         embed_dim: int,
         include_cls: bool = False,
+        init_std: float = 0.02,
     ) -> None:
         """Initialize PositionalEmbedding2D module.
 
@@ -177,16 +178,19 @@ class PositionalEmbedding2D(nn.Module):  # type: ignore
             Embedding dimension of tokens.
         include_cls : bool, default=False
             Whether to include position for a CLS token at the beginning.
+        init_std : float, default=0.02
+            Standard deviation for parameter initialization.
         """
         super().__init__()
         seq_len = num_patches + (1 if include_cls else 0)
+        self.init_std = init_std
         self.pos_embed = nn.Parameter(torch.zeros(1, seq_len, embed_dim))
 
         self._init_weights()
 
     def _init_weights(self) -> None:
         """Initialize positional embedding weights."""
-        nn.init.trunc_normal_(self.pos_embed, std=0.02)
+        nn.init.trunc_normal_(self.pos_embed, std=self.init_std)
 
     def forward(self, x: Tensor) -> Tensor:
         """Add positional embeddings to input tokens.

--- a/energy_transformer/spec/realise.py
+++ b/energy_transformer/spec/realise.py
@@ -845,6 +845,7 @@ def _realise_pos_embed(spec: PosEmbedSpec, info: SpecInfo) -> nn.Module:
             num_patches=info.token_count,
             embed_dim=info.embedding_dim,
             include_cls=spec.include_cls,
+            init_std=spec.init_std,
         )
     except ImportError as e:
         raise RealisationError(

--- a/tests/test_positional_embedding.py
+++ b/tests/test_positional_embedding.py
@@ -1,0 +1,11 @@
+import torch
+from energy_transformer.spec import PosEmbedSpec
+from energy_transformer.spec.realise import realise, SpecInfo
+
+def test_positional_embedding_init_std():
+    torch.manual_seed(0)
+    spec = PosEmbedSpec(include_cls=False, init_std=0.1)
+    info = SpecInfo(embedding_dim=8, token_count=4)
+    module = realise(spec, info)
+    # Standard deviation should be close to the specified value
+    assert torch.isclose(module.pos_embed.std(), torch.tensor(0.1), atol=0.02)


### PR DESCRIPTION
## Summary
- allow `PositionalEmbedding2D` to accept custom `init_std`
- pass `init_std` through the `PosEmbedSpec` realiser
- test that custom `init_std` is respected

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*