### PR TITLE
Fix mypy errors and ignore tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,10 @@ disallow_untyped_defs = true
 check_untyped_defs = true
 disallow_incomplete_defs = true
 
+[[tool.mypy.overrides]]
+module = ["tests.*"]
+ignore_errors = true
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]

--- a/tests/test_positional_embedding.py
+++ b/tests/test_positional_embedding.py
@@ -4,10 +4,11 @@ from energy_transformer.spec import PosEmbedSpec
 from energy_transformer.spec.realise import SpecInfo, realise
 
 
-def test_positional_embedding_init_std():
+def test_positional_embedding_init_std() -> None:
     torch.manual_seed(0)
     spec = PosEmbedSpec(include_cls=False, init_std=0.1)
     info = SpecInfo(embedding_dim=8, token_count=4)
     module = realise(spec, info)
+    assert module is not None
     # Standard deviation should be close to the specified value
     assert torch.isclose(module.pos_embed.std(), torch.tensor(0.1), atol=0.02)

--- a/tests/unit/layers/test_attention.py
+++ b/tests/unit/layers/test_attention.py
@@ -9,7 +9,14 @@ from energy_transformer.layers.attention import (
 )
 
 
-def manual_energy(g, w_k, w_q, beta, include_diag=True, attn_mask=None):
+def manual_energy(
+    g: torch.Tensor,
+    w_k: torch.Tensor,
+    w_q: torch.Tensor,
+    beta: float,
+    include_diag: bool = True,
+    attn_mask: torch.Tensor | None = None,
+) -> torch.Tensor:
     k = torch.einsum("nd,hyd->nhy", g, w_k)
     q = torch.einsum("nd,hyd->nhy", g, w_q)
     a = torch.einsum("nhy,mhy->hnm", k, q)
@@ -22,7 +29,7 @@ def manual_energy(g, w_k, w_q, beta, include_diag=True, attn_mask=None):
     return -(1 / beta) * lse.sum()
 
 
-def test_get_diag_mask_caches_by_length():
+def test_get_diag_mask_caches_by_length() -> None:
     clear_diag_cache()
     mask1 = _get_diag_mask(torch.device("cpu"), 4)
     mask2 = _get_diag_mask(torch.device("cpu"), 4)
@@ -37,7 +44,7 @@ def test_get_diag_mask_caches_by_length():
     "shape,chunk",
     [((2, 5), 10), ((3, 2048), 512)],
 )
-def test_chunked_logsumexp_matches_torch(shape, chunk):
+def test_chunked_logsumexp_matches_torch(shape: tuple[int, int], chunk: int) -> None:
     torch.manual_seed(0)
     logits = torch.randn(*shape)
     expected = torch.logsumexp(logits, dim=-1)
@@ -45,7 +52,7 @@ def test_chunked_logsumexp_matches_torch(shape, chunk):
     assert torch.allclose(result, expected, atol=1e-6)
 
 
-def test_attention_energy_matches_manual():
+def test_attention_energy_matches_manual() -> None:
     g = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
     attn = MultiHeadEnergyAttention(
         in_dim=2,
@@ -63,7 +70,7 @@ def test_attention_energy_matches_manual():
     assert torch.allclose(result, expected)
 
 
-def test_attention_single_token_returns_zero():
+def test_attention_single_token_returns_zero() -> None:
     g = torch.randn(1, 2)
     attn = MultiHeadEnergyAttention(
         in_dim=2,

--- a/tests/unit/layers/test_base.py
+++ b/tests/unit/layers/test_base.py
@@ -1,7 +1,12 @@
 import pytest
 import torch
 
-from energy_transformer.layers.base import _validate_scalar_energy, BaseLayerNorm, BaseEnergyAttention, BaseHopfieldNetwork
+from energy_transformer.layers.base import (
+    BaseEnergyAttention,
+    BaseHopfieldNetwork,
+    BaseLayerNorm,
+    _validate_scalar_energy,
+)
 
 
 class DummyLayerNorm(BaseLayerNorm):
@@ -19,19 +24,19 @@ class DummyHopfieldNetwork(BaseHopfieldNetwork):
         return g.mean()
 
 
-def test_validate_scalar_energy_accepts_scalar():
+def test_validate_scalar_energy_accepts_scalar() -> None:
     energy = torch.tensor(3.14)
     # Should not raise when energy is scalar
     _validate_scalar_energy(energy, "test")
 
 
-def test_validate_scalar_energy_rejects_tensor():
+def test_validate_scalar_energy_rejects_tensor() -> None:
     energy = torch.tensor([1.0, 2.0])
     with pytest.raises(ValueError, match="must return scalar energy tensor"):
         _validate_scalar_energy(energy, "mycomp")
 
 
-def test_default_reset_parameters_return_none():
+def test_default_reset_parameters_return_none() -> None:
     assert DummyLayerNorm().reset_parameters() is None
     assert DummyEnergyAttention().reset_parameters() is None
     assert DummyHopfieldNetwork().reset_parameters() is None

--- a/tests/unit/layers/test_embeddings.py
+++ b/tests/unit/layers/test_embeddings.py
@@ -2,33 +2,33 @@ import pytest
 import torch
 
 from energy_transformer.layers.embeddings import (
-    _to_pair,
     PatchEmbedding,
     PositionalEmbedding2D,
+    _to_pair,
 )
 from energy_transformer.layers.tokens import CLSToken
 
 
 @pytest.mark.parametrize("inp,expected", [(3, (3, 3)), ((2, 5), (2, 5))])
-def test_to_pair(inp, expected):
+def test_to_pair(inp: int | tuple[int, int], expected: tuple[int, int]) -> None:
     assert _to_pair(inp) == expected
 
 
-def test_patch_embedding_output_shape():
+def test_patch_embedding_output_shape() -> None:
     patch = PatchEmbedding(img_size=4, patch_size=2, in_chans=3, embed_dim=8)
     x = torch.randn(1, 3, 4, 4)
     out = patch(x)
     assert out.shape == (1, 4, 8)
 
 
-def test_patch_embedding_raises_for_wrong_size():
+def test_patch_embedding_raises_for_wrong_size() -> None:
     patch = PatchEmbedding(img_size=4, patch_size=2, in_chans=3, embed_dim=8)
     x = torch.randn(1, 3, 5, 4)
     with pytest.raises(AssertionError):
         patch(x)
 
 
-def test_cls_token_prepends_token():
+def test_cls_token_prepends_token() -> None:
     tok = CLSToken(embed_dim=5)
     with torch.no_grad():
         tok.cls_token.fill_(2.0)
@@ -39,7 +39,7 @@ def test_cls_token_prepends_token():
     assert torch.all(out[:, 1:] == 0)
 
 
-def test_positional_embedding_adds_values():
+def test_positional_embedding_adds_values() -> None:
     pos = PositionalEmbedding2D(num_patches=4, embed_dim=2, include_cls=True)
     with torch.no_grad():
         pos.pos_embed.fill_(1.0)

--- a/tests/unit/layers/test_heads.py
+++ b/tests/unit/layers/test_heads.py
@@ -3,7 +3,7 @@ import torch
 from energy_transformer.layers.heads import ClassificationHead, FeatureHead
 
 
-def test_classification_head_output_shape():
+def test_classification_head_output_shape() -> None:
     head = ClassificationHead(embed_dim=4, num_classes=3, drop_rate=0.0)
     x = torch.ones(2, 1, 4)
     out = head(x)
@@ -11,14 +11,14 @@ def test_classification_head_output_shape():
     assert torch.all(out == 0)
 
 
-def test_classification_head_pooling():
+def test_classification_head_pooling() -> None:
     head = ClassificationHead(embed_dim=4, num_classes=2, use_cls_token=False, drop_rate=0.0)
     x = torch.randn(2, 3, 4)
     out = head(x)
     assert out.shape == (2, 2)
 
 
-def test_feature_head_global_avg():
+def test_feature_head_global_avg() -> None:
     head = FeatureHead(use_cls_token=False)
     x = torch.arange(6.0).view(1, 3, 2)
     out = head(x)

--- a/tests/unit/layers/test_hopfield.py
+++ b/tests/unit/layers/test_hopfield.py
@@ -7,21 +7,21 @@ import torch
 from energy_transformer.layers.hopfield import (
     ActivationFunction,
     HopfieldNetwork,
-    get_energy_transformer_init_std,
     get_energy_function,
+    get_energy_transformer_init_std,
     he_scaled_init_std,
     quadratic_energy,
     register_energy_function,
 )
 
 
-def test_he_scaled_init_std_formula():
+def test_he_scaled_init_std_formula() -> None:
     assert math.isclose(he_scaled_init_std(4), math.sqrt(2.0 / 4))
     assert math.isclose(he_scaled_init_std(4, 8), math.sqrt(2.0 / 8))
     assert math.isclose(get_energy_transformer_init_std(3, 6), he_scaled_init_std(3, 6))
 
 
-def test_get_energy_function_values():
+def test_get_energy_function_values() -> None:
     h = torch.tensor([1.0, -2.0])
     relu_fn = get_energy_function(ActivationFunction.RELU)
     softmax_fn = get_energy_function(ActivationFunction.SOFTMAX)
@@ -34,7 +34,7 @@ def test_get_energy_function_values():
     assert torch.allclose(tanh_fn(h), -torch.sum(torch.log(torch.cosh(h.clamp(-10, 10)))))
 
 
-def test_register_energy_function_decorator():
+def test_register_energy_function_decorator() -> None:
     @register_energy_function("dummy")
     def dummy_energy(h: torch.Tensor) -> torch.Tensor:
         return -h.sum()
@@ -43,12 +43,12 @@ def test_register_energy_function_decorator():
     assert dummy_energy(torch.tensor([1.0, 2.0])) == -3.0
 
 
-def test_hopfieldnetwork_custom_activation_requires_energy_fn():
+def test_hopfieldnetwork_custom_activation_requires_energy_fn() -> None:
     with pytest.raises(ValueError):
         HopfieldNetwork(in_dim=1, activation=ActivationFunction.CUSTOM)
 
 
-def test_hopfieldnetwork_warning_energy_fn_ignored():
+def test_hopfieldnetwork_warning_energy_fn_ignored() -> None:
     with warnings.catch_warnings(record=True) as w:
         HopfieldNetwork(
             in_dim=1,
@@ -61,7 +61,7 @@ def test_hopfieldnetwork_warning_energy_fn_ignored():
         )
 
 
-def test_hopfieldnetwork_forward_quadratic_energy():
+def test_hopfieldnetwork_forward_quadratic_energy() -> None:
     net = HopfieldNetwork(
         in_dim=2,
         hidden_dim=1,

--- a/tests/unit/layers/test_layer_norm.py
+++ b/tests/unit/layers/test_layer_norm.py
@@ -1,10 +1,10 @@
 import torch
-import torch.nn.functional as F
+import torch.nn.functional as functional
 
 from energy_transformer.layers.layer_norm import LayerNorm
 
 
-def test_layernorm_matches_torch():
+def test_layernorm_matches_torch() -> None:
     torch.manual_seed(0)
     ln = LayerNorm(in_dim=3)
     x = torch.randn(2, 3)
@@ -12,13 +12,13 @@ def test_layernorm_matches_torch():
 
     ref = torch.nn.LayerNorm(3, eps=ln.eps)
     with torch.no_grad():
-        ref.weight.fill_(F.softplus(ln.logγ).item())
+        ref.weight.fill_(functional.softplus(ln.logγ).item())
         ref.bias.copy_(ln.δ)
     expected = ref(x)
     assert torch.allclose(out, expected, atol=1e-6)
 
 
-def test_energy_gradient_equals_output():
+def test_energy_gradient_equals_output() -> None:
     ln = LayerNorm(in_dim=4)
     x = torch.randn(2, 4, requires_grad=True)
     g = ln(x)
@@ -27,7 +27,7 @@ def test_energy_gradient_equals_output():
     assert torch.allclose(x.grad, g, atol=1e-6)
 
 
-def test_export_standard_layernorm():
+def test_export_standard_layernorm() -> None:
     ln = LayerNorm(in_dim=2)
     ref = ln.export_standard_layernorm()
     x = torch.randn(3, 2)

--- a/tests/unit/models/test_vision_utils.py
+++ b/tests/unit/models/test_vision_utils.py
@@ -3,7 +3,7 @@ import pytest
 from energy_transformer.models.vision.utils import create_model_config
 
 
-def test_create_model_config_defaults():
+def test_create_model_config_defaults() -> None:
     cfg = create_model_config()
     assert cfg["embed_dim"] == 768
     assert cfg["img_size"] == 224
@@ -13,13 +13,13 @@ def test_create_model_config_defaults():
     assert cfg["et_steps"] == 4
 
 
-def test_create_model_config_override_and_size():
+def test_create_model_config_override_and_size() -> None:
     cfg = create_model_config("small", img_size=128, num_classes=10)
     assert cfg["embed_dim"] == 384
     assert cfg["img_size"] == 128
     assert cfg["num_classes"] == 10
 
 
-def test_create_model_config_unknown_size():
+def test_create_model_config_unknown_size() -> None:
     with pytest.raises(ValueError):
         create_model_config("giant")

--- a/tests/unit/spec/test_combinators.py
+++ b/tests/unit/spec/test_combinators.py
@@ -1,4 +1,5 @@
 import pytest
+
 from energy_transformer.spec import (
     CLSTokenSpec,
     ETSpec,
@@ -15,7 +16,7 @@ def make_patch(embed_dim: int = 64) -> PatchEmbedSpec:
     return PatchEmbedSpec(img_size=32, patch_size=16, embed_dim=embed_dim)
 
 
-def test_seq_flattens_and_len():
+def test_seq_flattens_and_len() -> None:
     pe = make_patch()
     cls = CLSTokenSpec()
     ln = LayerNormSpec()
@@ -28,30 +29,30 @@ def test_seq_flattens_and_len():
     assert isinstance(model[1:], type(model))
 
 
-def test_seq_embedding_and_token_count():
+def test_seq_embedding_and_token_count() -> None:
     model = seq(make_patch(), CLSTokenSpec(), LayerNormSpec())
     assert model.get_embedding_dim() == 64
     # PatchEmbed produces 4 tokens for 32/16, plus 1 from CLS
     assert model.get_token_count() == 5
 
 
-def test_seq_modifies_tokens():
+def test_seq_modifies_tokens() -> None:
     model = seq(make_patch(), CLSTokenSpec(), LayerNormSpec())
     assert model.modifies_tokens()
 
 
-def test_seq_validate_requires_upstream():
+def test_seq_validate_requires_upstream() -> None:
     model = seq(CLSTokenSpec())
     with pytest.raises(ValidationError):
         model.validate()
 
 
-def test_seq_validate_success():
+def test_seq_validate_success() -> None:
     model = seq(make_patch(), CLSTokenSpec())
     model.validate()  # should not raise
 
 
-def test_repeat_basic_and_flatten():
+def test_repeat_basic_and_flatten() -> None:
     ln = LayerNormSpec()
     repeated = repeat(ln, 3)
     assert len(repeated) == 3
@@ -63,31 +64,31 @@ def test_repeat_basic_and_flatten():
 
 
 @pytest.mark.parametrize("times", [0, 1])
-def test_repeat_zero_and_one(times: int):
+def test_repeat_zero_and_one(times: int) -> None:
     ln = LayerNormSpec()
     r = repeat(ln, times)
     assert len(r) == times
 
 
-def test_repeat_invalid():
+def test_repeat_invalid() -> None:
     with pytest.raises(ValueError):
         repeat(LayerNormSpec(), -1)
     with pytest.raises(TypeError):
         repeat(123, 2)
 
 
-def test_parallel_concat_embedding_dim():
+def test_parallel_concat_embedding_dim() -> None:
     p = parallel(make_patch(64), make_patch(32), join_mode="concat")
     assert p.get_embedding_dim() == 96
 
 
-def test_parallel_add_dimension_mismatch_validation():
+def test_parallel_add_dimension_mismatch_validation() -> None:
     p = parallel(make_patch(64), make_patch(32), join_mode="add")
     with pytest.raises(ValidationError):
         p.validate(upstream_embedding_dim=64)
 
 
-def test_parallel_add_operator():
+def test_parallel_add_operator() -> None:
     b1 = parallel(make_patch(64), join_mode="concat")
     b2 = make_patch(32)
     combined = b1 + b2
@@ -95,7 +96,7 @@ def test_parallel_add_operator():
     combined2 = b1 + parallel(b2, join_mode="concat")
     assert len(combined2) == 2
 
-def test_sequential_getitem_and_slice():
+def test_sequential_getitem_and_slice() -> None:
     model = seq(make_patch(), CLSTokenSpec(), LayerNormSpec())
     assert model[0] is model.parts[0]
     sliced = model[1:]
@@ -103,14 +104,14 @@ def test_sequential_getitem_and_slice():
     assert sliced.parts == model.parts[1:]
 
 
-def test_sequential_find_and_count_parts():
+def test_sequential_find_and_count_parts() -> None:
     model = seq(make_patch(), repeat(ETSpec(), 2), LayerNormSpec())
     parts = model.find_parts_by_type(ETSpec)
     assert len(parts) == 2
     assert model.count_parts_by_type(ETSpec) == 2
 
 
-def test_parallel_getitem_and_slice():
+def test_parallel_getitem_and_slice() -> None:
     p = parallel(make_patch(), make_patch(32), join_mode="concat")
     assert p[0] is p.branches[0]
     sliced = p[1:]
@@ -118,7 +119,7 @@ def test_parallel_getitem_and_slice():
     assert sliced.branches == p.branches[1:]
 
 
-def test_parallel_find_branches_by_type():
+def test_parallel_find_branches_by_type() -> None:
     p = parallel(make_patch(), LayerNormSpec(), make_patch(32), join_mode="concat")
     found = p.find_branches_by_type(PatchEmbedSpec)
     assert len(found) == 2

--- a/tests/unit/spec/test_primitives.py
+++ b/tests/unit/spec/test_primitives.py
@@ -18,42 +18,42 @@ from energy_transformer.spec import (
 
 
 @pytest.mark.parametrize("value", [1, 0.1, 5])
-def test_validate_positive_pass(value):
+def test_validate_positive_pass(value: float | int) -> None:
     validate_positive(value, "test")
 
 
 @pytest.mark.parametrize("value", [0, -1, "a"])
-def test_validate_positive_fail(value):
+def test_validate_positive_fail(value: object) -> None:
     with pytest.raises(ValidationError):
         validate_positive(value, "val")
 
 
 @pytest.mark.parametrize("value", [0, 0.5, 1])
-def test_validate_probability_pass(value):
+def test_validate_probability_pass(value: float | int) -> None:
     validate_probability(value, "p")
 
 
 @pytest.mark.parametrize("value", [-0.1, 1.1, "b"])
-def test_validate_probability_fail(value):
+def test_validate_probability_fail(value: object) -> None:
     with pytest.raises(ValidationError):
         validate_probability(value, "p")
 
 
-def test_to_pair_from_int():
+def test_to_pair_from_int() -> None:
     assert to_pair(4) == (4, 4)
 
 
-def test_to_pair_from_tuple():
+def test_to_pair_from_tuple() -> None:
     assert to_pair((2, 3)) == (2, 3)
 
 
 @pytest.mark.parametrize("value", [(-1, 2), (1, -2), (1, 2, 3), "x"])
-def test_to_pair_invalid(value):
+def test_to_pair_invalid(value: object) -> None:
     with pytest.raises(ValidationError):
         to_pair(value)
 
 
-def test_base_validate_requires_context():
+def test_base_validate_requires_context() -> None:
     spec = LayerNormSpec()
     with pytest.raises(ValidationError):
         spec.validate()
@@ -61,18 +61,18 @@ def test_base_validate_requires_context():
     spec.validate(upstream_embedding_dim=16)
 
 
-def test_layer_norm_estimate():
+def test_layer_norm_estimate() -> None:
     spec = LayerNormSpec()
     assert spec.estimate_params(32) == 64
 
 
-def test_mhea_effective_beta():
+def test_mhea_effective_beta() -> None:
     spec = MHEASpec(num_heads=2, head_dim=16)
     expected = 1.0 / math.sqrt(16)
     assert math.isclose(spec.get_effective_beta(), expected)
 
 
-def test_mhea_estimate_params_with_bias():
+def test_mhea_estimate_params_with_bias() -> None:
     spec = MHEASpec(num_heads=2, head_dim=4, bias=True)
     params = spec.estimate_params(32)
     assert params == (2 * 2 * 4 * 32) + (2 * 2 * 4)
@@ -82,30 +82,30 @@ def test_mhea_estimate_params_with_bias():
     "num_heads,head_dim,dropout",
     [(0, 4, 0.0), (2, 0, 0.0), (2, 4, -0.1), (2, 4, 1.1)],
 )
-def test_mhea_validate_bad(num_heads, head_dim, dropout):
+def test_mhea_validate_bad(num_heads: int, head_dim: int, dropout: float) -> None:
     with pytest.raises(ValidationError):
         MHEASpec(num_heads=num_heads, head_dim=head_dim, dropout=dropout)
 
 
-def test_mhea_validate_total_dim():
+def test_mhea_validate_total_dim() -> None:
     with pytest.raises(ValidationError):
         MHEASpec(num_heads=64, head_dim=100)  # total_dim > 4096
 
 
-def test_hnspec_hidden_dim_and_estimate():
+def test_hnspec_hidden_dim_and_estimate() -> None:
     spec = HNSpec(hidden_dim=10, bias=True)
     assert spec.get_effective_hidden_dim(32) == 10
     assert spec.estimate_params(32) == (10 * 32) + 10
 
 
-def test_hnspec_multiplier_limits():
+def test_hnspec_multiplier_limits() -> None:
     with pytest.raises(ValidationError):
         HNSpec(multiplier=0)
     with pytest.raises(ValidationError):
         HNSpec(multiplier=9.0)
 
 
-def test_et_spec_estimate_params():
+def test_et_spec_estimate_params() -> None:
     spec = ETSpec(
         steps=2,
         alpha=0.5,
@@ -121,7 +121,7 @@ def test_et_spec_estimate_params():
     assert total == ln + attn + hn
 
 
-def test_cls_token_spec_behaviour():
+def test_cls_token_spec_behaviour() -> None:
     spec = CLSTokenSpec()
     assert spec.requires_embedding_dim()
     assert spec.adds_tokens() == 1
@@ -129,7 +129,7 @@ def test_cls_token_spec_behaviour():
     assert spec.estimate_params(32) == 32
 
 
-def test_patch_embed_spec_tokens_and_params():
+def test_patch_embed_spec_tokens_and_params() -> None:
     spec = PatchEmbedSpec(img_size=8, patch_size=4, embed_dim=16, in_chans=3, bias=False)
     assert spec.get_token_count() == 4
     assert spec.get_embedding_dim() == 16
@@ -138,12 +138,12 @@ def test_patch_embed_spec_tokens_and_params():
     assert spec.estimate_params() == 3 * patch_area * 16
 
 
-def test_patch_embed_validation_divisible():
+def test_patch_embed_validation_divisible() -> None:
     with pytest.raises(ValidationError):
         PatchEmbedSpec(img_size=7, patch_size=4, embed_dim=8)
 
 
-def test_pos_embed_spec_requirements_and_estimate():
+def test_pos_embed_spec_requirements_and_estimate() -> None:
     spec = PosEmbedSpec(include_cls=True)
     assert spec.requires_embedding_dim()
     assert spec.requires_token_count()

--- a/tests/unit/spec/test_realise.py
+++ b/tests/unit/spec/test_realise.py
@@ -16,18 +16,18 @@ from energy_transformer.spec import (
 from energy_transformer.spec.realise import RealisationError, realise
 
 
-def test_spec_immutability():
+def test_spec_immutability() -> None:
     spec = MHEASpec(num_heads=2, head_dim=8)
     with pytest.raises(FrozenInstanceError):
         spec.num_heads = 4  # type: ignore[misc]
 
 
-def test_pos_embed_validation_error():
+def test_pos_embed_validation_error() -> None:
     with pytest.raises(ValidationError):
         PosEmbedSpec(init_std=0.0)
 
 
-def test_seq_dimension_propagation_and_validation():
+def test_seq_dimension_propagation_and_validation() -> None:
     model = seq(
         PatchEmbedSpec(img_size=8, patch_size=4, embed_dim=16),
         CLSTokenSpec(),
@@ -39,7 +39,7 @@ def test_seq_dimension_propagation_and_validation():
     model.validate()  # should not raise
 
 
-def test_parallel_add_mode_dimension():
+def test_parallel_add_mode_dimension() -> None:
     p = parallel(
         PatchEmbedSpec(img_size=8, patch_size=4, embed_dim=16),
         PatchEmbedSpec(img_size=8, patch_size=4, embed_dim=16),
@@ -48,7 +48,7 @@ def test_parallel_add_mode_dimension():
     assert p.get_embedding_dim() == 16
 
 
-def test_parallel_add_mode_unknown_dimension():
+def test_parallel_add_mode_unknown_dimension() -> None:
     p = parallel(
         PatchEmbedSpec(img_size=8, patch_size=4, embed_dim=16),
         LayerNormSpec(),
@@ -57,7 +57,7 @@ def test_parallel_add_mode_unknown_dimension():
     assert p.get_embedding_dim() == 16
 
 
-def test_realise_simple_sequence():
+def test_realise_simple_sequence() -> None:
     spec = seq(
         PatchEmbedSpec(img_size=4, patch_size=2, embed_dim=8, in_chans=3),
         CLSTokenSpec(),
@@ -70,6 +70,6 @@ def test_realise_simple_sequence():
     assert out.shape == (1, 5, 8)
 
 
-def test_realise_requires_context_error():
+def test_realise_requires_context_error() -> None:
     with pytest.raises(RealisationError):
         realise(CLSTokenSpec())


### PR DESCRIPTION
## Summary
- add mypy override for tests
- annotate tests with return types and fix typing issues
- clean up test imports and variables for ruff

## Testing
- `mypy .`
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*