### PR TITLE
Add comprehensive LayerNorm tests

### DIFF
--- a/tests/unit/layers/test_layer_norm.py
+++ b/tests/unit/layers/test_layer_norm.py
@@ -1,7 +1,11 @@
+import pytest
 import torch
 import torch.nn.functional as functional
 
-from energy_transformer.layers.layer_norm import LayerNorm
+from energy_transformer.layers.layer_norm import (
+    LayerNorm,
+    _functional_layernorm_energy,
+)
 
 
 def test_layernorm_matches_torch() -> None:
@@ -34,3 +38,55 @@ def test_export_standard_layernorm() -> None:
     out1 = ln(x)
     out2 = ref(x)
     assert torch.allclose(out1, out2, atol=1e-6)
+
+
+def test_reset_parameters_initializes_values() -> None:
+    ln = LayerNorm(in_dim=4)
+    γ = functional.softplus(ln.logγ).item()
+    assert γ == pytest.approx(1.0)
+    assert torch.all(ln.δ == 0)
+
+    with torch.no_grad():
+        ln.logγ.fill_(2.0)
+        ln.δ.fill_(1.0)
+
+    ln.reset_parameters()
+    γ = functional.softplus(ln.logγ).item()
+    assert γ == pytest.approx(1.0)
+    assert torch.all(ln.δ == 0)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_mixed_precision_matches_float32(dtype: torch.dtype) -> None:
+    ln = LayerNorm(in_dim=3)
+    x = torch.randn(2, 3)
+    out_fp32 = ln(x)
+
+    x_mp = x.to(dtype)
+    out_mp = ln(x_mp)
+    assert out_mp.dtype == dtype
+    assert torch.allclose(out_mp.to(torch.float32), out_fp32, atol=5e-3)
+
+
+def test_functional_layernorm_energy_equivalence() -> None:
+    ln = LayerNorm(in_dim=3)
+    with torch.no_grad():
+        ln.logγ.fill_(0.5)
+        ln.δ.copy_(torch.tensor([0.1, -0.2, 0.3]))
+
+    x = torch.randn(4, 3)
+    out_mod = ln(x)
+    out_func = _functional_layernorm_energy(x, ln.logγ, ln.δ, eps=ln.eps)
+    assert torch.allclose(out_mod, out_func, atol=1e-6)
+
+
+def test_export_standard_layernorm_parameters() -> None:
+    ln = LayerNorm(in_dim=5)
+    with torch.no_grad():
+        ln.logγ.fill_(0.3)
+        ln.δ.uniform_(-1, 1)
+
+    ref = ln.export_standard_layernorm()
+    γ = functional.softplus(ln.logγ).item()
+    assert torch.allclose(ref.weight, torch.full((5,), γ))
+    assert torch.allclose(ref.bias, ln.δ)


### PR DESCRIPTION
## Summary
- expand unit tests for `LayerNorm`

## Testing
- `ruff check .`
- `ruff format --check .`
- `mypy .` *(fails: 34 errors)*
- `pytest -q`