### PR TITLE
Add unit tests for embeddings

### DIFF
--- a/tests/unit/layers/test_embeddings.py
+++ b/tests/unit/layers/test_embeddings.py
@@ -47,3 +47,35 @@ def test_positional_embedding_adds_values() -> None:
     out = pos(x)
     assert out.shape == (1, 5, 2)
     assert torch.allclose(out, torch.ones_like(out))
+
+def test_patch_embedding_num_patches_and_conv_params() -> None:
+    patch = PatchEmbedding(img_size=(4, 6), patch_size=(2, 3), in_chans=1, embed_dim=4)
+    assert patch.num_patches == 4
+    assert patch.proj.kernel_size == (2, 3)
+    assert patch.proj.stride == (2, 3)
+
+
+def test_patch_embedding_non_square_image_and_patch() -> None:
+    patch = PatchEmbedding(img_size=(4, 6), patch_size=(2, 3), in_chans=1, embed_dim=5)
+    x = torch.randn(2, 1, 4, 6)
+    out = patch(x)
+    assert out.shape == (2, 4, 5)
+
+
+def test_patch_embedding_bias_optional() -> None:
+    patch = PatchEmbedding(img_size=2, patch_size=1, in_chans=1, embed_dim=3, bias=False)
+    assert patch.proj.bias is None
+
+
+def test_positional_embedding_parameter_shapes() -> None:
+    pos_no_cls = PositionalEmbedding2D(num_patches=3, embed_dim=2, include_cls=False)
+    pos_with_cls = PositionalEmbedding2D(num_patches=3, embed_dim=2, include_cls=True)
+    assert pos_no_cls.pos_embed.shape == (1, 3, 2)
+    assert pos_with_cls.pos_embed.shape == (1, 4, 2)
+
+
+def test_positional_embedding_preserves_dtype() -> None:
+    pos = PositionalEmbedding2D(num_patches=2, embed_dim=3)
+    x = torch.zeros(1, 2, 3, dtype=torch.float16)
+    out = pos(x)
+    assert out.dtype == torch.float16


### PR DESCRIPTION
## Summary
- add tests for non-square patch embedding behavior
- cover optional bias flag and positional embedding shapes
- ensure positional embeddings preserve dtype

## Testing
- `pytest -q`