### PR TITLE
Add tests for simplicial module

### DIFF
--- a/tests/unit/layers/test_simplicial.py
+++ b/tests/unit/layers/test_simplicial.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 
 from energy_transformer.layers.simplicial import (
+    QuerySpec,
     SimplexGenerator,
     SimplicialComplex,
     UnionSimplexGenerator,
@@ -13,7 +14,9 @@ from energy_transformer.layers.simplicial import (
     canonical,
     energy,
     lse,
+    membership,
     unrank,
+    update,
 )
 
 
@@ -117,3 +120,56 @@ def test_energy_matches_lse_relationship() -> None:
     lse_val = lse(β, ξ, g, κ)
     expected = -lse_val + 0.5 * torch.dot(g, g)
     assert torch.allclose(e, expected)
+
+
+def test_query_spec_proportions_validation() -> None:
+    with pytest.raises(ValueError):
+        QuerySpec(proportions={0: 0.6, 1: 0.5})
+
+
+def test_membership_invalid_vertex() -> None:
+    with pytest.raises(ValueError):
+        membership(((0, 1), (3,)), 3, "cpu", "torch.float32")
+
+
+def test_membership_empty_complex_returns_empty_matrix() -> None:
+    μ = membership((), 4, "cpu", "torch.float32").coalesce()
+    assert μ.shape == torch.Size([4, 0])
+    assert μ._nnz() == 0
+
+
+def test_simplex_query_filtering_and_count() -> None:
+    complex = SimplicialComplex([(0, 1, 2), (1, 2, 3)])
+    query = complex.simplices(1).containing(0)
+    collected = query.collect()
+    assert set(collected[1]) == {frozenset({0, 1}), frozenset({0, 2})}
+    count = query.count()
+    assert count == {1: 2}
+
+
+def _manual_update(
+    β: float, ξ: torch.Tensor, g: torch.Tensor, κ: list[list[int]]
+) -> torch.Tensor:
+    μ = _get_membership(κ, g.shape[0], torch.device("cpu"), ξ.dtype)
+    y = ξ * g  # (P, N)
+    dot = torch.sparse.mm(μ.t(), y.t()).t()  # (P, |κ|)
+    α = torch.softmax(dot.sum(dim=1) / β, dim=0)
+    return α @ ξ
+
+
+def test_update_matches_manual_computation() -> None:
+    torch.manual_seed(0)
+    ξ = torch.randn(2, 3)
+    g = torch.randn(3)
+    κ = [(0, 1), (2,)]
+    β = 0.5
+    out = update(β, ξ, g, κ)
+    expected = _manual_update(β, ξ, g, κ)
+    assert torch.allclose(out, expected)
+
+
+def test_update_raises_for_shape_mismatch() -> None:
+    ξ = torch.randn(1, 2)
+    g = torch.randn(3)
+    with pytest.raises(ValueError):
+        update(1.0, ξ, g, [(0,)])


### PR DESCRIPTION
## Summary
- expand simplicial tests
- verify QuerySpec and membership behaviour
- check SimplexQuery filtering
- test update computation

## Testing
- `pytest -q`