### PR TITLE
Fix eval RCE and typing errors

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release is supported at this time.
+
+## Reporting a Vulnerability
+
+Please report security issues privately by emailing the maintainer. Do not open
+public GitHub issues for security problems.
+
+This release fixes a remote code execution vulnerability in the `Dimension`
+formula evaluation by replacing `eval()` with a safe parser.

--- a/energy_transformer/__init__.py
+++ b/energy_transformer/__init__.py
@@ -90,6 +90,6 @@ __all__ = [
     "configure_realisation",
 ]
 
-__version__ = "0.1.0"
+__version__ = "0.2.0-alpha1"
 __author__ = "Ayan Das <bvits@riseup.net>"
 __license__ = "Apache-2.0"

--- a/energy_transformer/spec/__init__.py
+++ b/energy_transformer/spec/__init__.py
@@ -221,7 +221,7 @@ if _LIBRARY_AVAILABLE:
     )
 
 # Version information
-__version__ = "0.1.0"
+__version__ = "0.2.0-alpha1"
 
 # Convenience aliases for common patterns
 Seq = seq

--- a/energy_transformer/spec/library.py
+++ b/energy_transformer/spec/library.py
@@ -55,8 +55,8 @@ def to_pair(x: int | tuple[int, int]) -> tuple[int, int]:
 def validate_positive(x: int | float | tuple[int | float, ...]) -> bool:
     """Validate that a value is positive."""
     if isinstance(x, tuple):
-        return all(isinstance(v, int | float) and v > 0 for v in x)
-    return isinstance(x, int | float) and x > 0
+        return all(isinstance(v, (int, float)) and v > 0 for v in x)
+    return isinstance(x, (int, float)) and x > 0
 
 
 def validate_probability(x: float) -> bool:

--- a/energy_transformer/spec/primitives.py
+++ b/energy_transformer/spec/primitives.py
@@ -86,7 +86,10 @@ class Dimension:
 
     Dimensions represent values that may not be known at specification time
     but can be resolved from context during realization. They support
-    formulas for computed dimensions and validation constraints.
+    formulas for computed dimensions and validation constraints. Formulas
+    support basic arithmetic (+, -, *, /), parentheses, and variables from
+    the context. Function calls and attribute access are disallowed to
+    prevent code execution.
 
     Parameters
     ----------
@@ -125,6 +128,131 @@ class Dimension:
         self.formula = formula
         self.constraints = constraints or []
 
+    def _tokenize(self, formula: str) -> list[tuple[str, str]]:
+        """Tokenize mathematical formula into (type, value) pairs."""
+        import re
+
+        TOKEN_REGEX = re.compile(
+            r"(?P<NUMBER>\d+(?:\.\d+)?)|"
+            r"(?P<IDENT>[a-zA-Z_][a-zA-Z0-9_]*)|"
+            r"(?P<PLUS>\+)|"
+            r"(?P<MINUS>-)|"
+            r"(?P<TIMES>\*)|"
+            r"(?P<DIVIDE>/)|"
+            r"(?P<LPAREN>\()|"
+            r"(?P<RPAREN>\))|"
+            r"(?P<WHITESPACE>\s+)|"
+            r"(?P<INVALID>.)",
+            re.VERBOSE,
+        )
+
+        tokens = []
+        for match in TOKEN_REGEX.finditer(formula):
+            kind = match.lastgroup
+            value = match.group()
+            if kind == "WHITESPACE":
+                continue
+            elif kind == "INVALID":
+                raise ValueError(f"Invalid character in formula: {value!r}")
+            tokens.append((kind, value))
+
+        return tokens
+
+    def _parse_expression(
+        self, tokens: list[tuple[str, str]], pos: int, variables: dict[str, int | None]
+    ) -> tuple[float, int]:
+        """Parse mathematical expression recursively."""
+        left, pos = self._parse_term(tokens, pos, variables)
+
+        while pos < len(tokens) and tokens[pos][0] in ("PLUS", "MINUS"):
+            op = tokens[pos][0]
+            pos += 1
+            right, pos = self._parse_term(tokens, pos, variables)
+            if op == "PLUS":
+                left = left + right
+            else:
+                left = left - right
+
+        return left, pos
+
+    def _parse_term(
+        self, tokens: list[tuple[str, str]], pos: int, variables: dict[str, int | None]
+    ) -> tuple[float, int]:
+        """Parse multiplication/division term."""
+        left, pos = self._parse_factor(tokens, pos, variables)
+
+        while pos < len(tokens) and tokens[pos][0] in ("TIMES", "DIVIDE"):
+            op = tokens[pos][0]
+            pos += 1
+            right, pos = self._parse_factor(tokens, pos, variables)
+            if op == "TIMES":
+                left = left * right
+            else:
+                if right == 0:
+                    raise ValueError("Division by zero")
+                left = left / right
+
+        return left, pos
+
+    def _parse_factor(
+        self, tokens: list[tuple[str, str]], pos: int, variables: dict[str, int | None]
+    ) -> tuple[float, int]:
+        """Parse number, variable, or parenthesized expression."""
+        if pos >= len(tokens):
+            raise ValueError("Unexpected end of expression")
+
+        token_type, token_value = tokens[pos]
+
+        if token_type == "NUMBER":
+            return float(token_value), pos + 1
+
+        elif token_type == "IDENT":
+            if token_value not in variables:
+                raise ValueError(f"Unknown variable: {token_value}")
+            value = variables[token_value]
+            if value is None:
+                raise ValueError(f"Variable {token_value} has no value")
+            return float(value), pos + 1
+
+        elif token_type == "LPAREN":
+            pos += 1  # Skip '('
+            value, pos = self._parse_expression(tokens, pos, variables)
+            if pos >= len(tokens) or tokens[pos][0] != "RPAREN":
+                raise ValueError("Missing closing parenthesis")
+            return value, pos + 1  # Skip ')'
+
+        elif token_type == "MINUS":
+            pos += 1  # Skip unary minus
+            value, pos = self._parse_factor(tokens, pos, variables)
+            return -value, pos
+
+        else:
+            raise ValueError(f"Unexpected token: {token_value}")
+
+    def _safe_eval_formula(
+        self, formula: str, variables: dict[str, int | None]
+    ) -> float | None:
+        """Safely evaluate mathematical formula without eval()."""
+        try:
+            tokens = self._tokenize(formula)
+            if not tokens:
+                return None
+
+            result, pos = self._parse_expression(tokens, 0, variables)
+
+            if pos < len(tokens):
+                raise ValueError(
+                    f"Unexpected token after expression: {tokens[pos][1]}"
+                )
+
+            return result
+        except Exception as e:  # pragma: no cover - debugging
+            import logging
+
+            logger = logging.getLogger(__name__)
+            logger.debug(f"Formula evaluation failed for {formula!r}: {e}")
+            return None
+
     def resolve(self, context: Context) -> int | None:
         """Resolve dimension value from context.
 
@@ -144,12 +272,11 @@ class Dimension:
             return self.value
 
         if self.formula:
-            # Safe formula evaluation with restricted namespace
             local_vars = {
                 name: context.get_dim(name) for name in context.dimensions
             }
             try:
-                result = eval(self.formula, {"__builtins__": {}}, local_vars)
+                result = self._safe_eval_formula(self.formula, local_vars)
                 return int(result) if result is not None else None
             except Exception:
                 return None
@@ -582,6 +709,25 @@ class Spec(ABC, metaclass=SpecMeta):
                         field_name=field_info.name,
                     )
 
+                if choices:
+                    choice_types = {type(c) for c in choices}
+                    if len(choice_types) > 1:
+                        import logging
+
+                        logger = logging.getLogger(__name__)
+                        logger.warning(
+                            f"Field {field_info.name} has choices with mixed types: {choice_types}"
+                        )
+
+                    value_type = type(value)
+                    if value_type not in choice_types and value in choices:
+                        raise ValidationError(
+                            f"Value type {value_type.__name__} doesn't match choice types {choice_types}",
+                            spec=self,
+                            field_name=field_info.name,
+                            suggestion="Ensure all choices have consistent types",
+                        )
+
     def validate(self, context: Context) -> list[str]:
         """Validate spec against context, returning issues.
 
@@ -733,7 +879,7 @@ class Spec(ABC, metaclass=SpecMeta):
             value = getattr(self, field_info.name)
             if isinstance(value, Spec):
                 children.append(value)
-            elif isinstance(value, list | tuple):
+            elif isinstance(value, (list, tuple)):
                 children.extend(v for v in value if isinstance(v, Spec))
         return children
 
@@ -787,7 +933,7 @@ class Spec(ABC, metaclass=SpecMeta):
             value = getattr(self, field_info.name)
             if isinstance(value, Spec):
                 value = value.to_dict()
-            elif isinstance(value, list | tuple):
+            elif isinstance(value, (list, tuple)):
                 value = [
                     v.to_dict() if isinstance(v, Spec) else v for v in value
                 ]

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,24 @@
+# Testing Instructions for PR1
+
+## Setup
+1. Install pytest: `pip install pytest pytest-cov`
+2. Run from repository root: `pytest tests/test_security_and_types.py -v`
+
+## Expected Results
+All tests should pass. Key verifications:
+
+1. **Security Tests**:
+   - All exploit attempts return None
+   - No actual code execution occurs
+   - Safe math formulas still work
+
+2. **Type Safety Tests**:
+   - isinstance() calls don't crash
+   - Type validation works for all cases
+
+3. **Integration Tests**:
+   - Real-world formulas calculate correctly
+   - System remains secure
+
+## Coverage
+Run with coverage: `pytest tests/test_security_and_types.py --cov=energy_transformer.spec --cov-report=html`

--- a/tests/test_security_and_types.py
+++ b/tests/test_security_and_types.py
@@ -1,0 +1,195 @@
+"""Test security fixes and type safety.
+
+This module verifies:
+1. eval() exploit prevention
+2. Type union crash fixes
+3. Choice validation type safety
+"""
+
+import pytest
+import sys
+import os
+from unittest.mock import patch
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from energy_transformer.spec.primitives import Dimension, Context, ValidationError
+from energy_transformer.spec.library import (
+    validate_positive,
+    validate_probability,
+    validate_dimension,
+)
+
+
+class TestSecurityFixes:
+    """Test that eval() exploits are prevented."""
+
+    def test_dimension_blocks_code_execution(self):
+        """Ensure malicious code cannot be executed through formulas."""
+        ctx = Context(dimensions={"x": 10, "y": 20})
+
+        dangerous_formulas = [
+            "__import__('os').system('echo pwned')",
+            "__import__('subprocess').call(['ls'])",
+            "exec('print(1)')",
+            "eval('1+1')",
+            "__builtins__['eval']('1+1')",
+            "globals()['__builtins__']['exec']('x=1')",
+            "[i for i in range(10**10)]",
+            "10**10**10",
+            "x.__class__.__bases__[0].__subclasses__()",
+            "().__class__.__bases__[0].__subclasses__()",
+            "print(x)",
+            "len([1,2,3])",
+            "max(1,2,3)",
+        ]
+
+        for formula in dangerous_formulas:
+            dim = Dimension("test", formula=formula)
+            result = dim.resolve(ctx)
+            assert result is None, f"Formula {formula!r} should fail to parse"
+
+    def test_dimension_allows_safe_math(self):
+        """Ensure legitimate mathematical formulas still work."""
+        ctx = Context(dimensions={"width": 224, "patch": 16, "heads": 12})
+
+        safe_formulas = [
+            ("width / patch", 14),
+            ("width * 2", 448),
+            ("width + patch", 240),
+            ("width - patch", 208),
+            ("(width / patch) * heads", 168),
+            ("width / patch / 2", 7),
+            ("-patch", -16),
+            ("patch * -1", -16),
+        ]
+
+        for formula, expected in safe_formulas:
+            dim = Dimension("test", formula=formula)
+            result = dim.resolve(ctx)
+            assert result == expected
+
+    def test_dimension_handles_missing_variables(self):
+        ctx = Context(dimensions={"x": 10})
+        dim = Dimension("test", formula="x + y")
+        assert dim.resolve(ctx) is None
+
+    def test_dimension_handles_none_values(self):
+        ctx = Context(dimensions={"x": 10, "y": None})
+        dim = Dimension("test", formula="x + y")
+        assert dim.resolve(ctx) is None
+
+    @patch('os.system')
+    def test_no_actual_execution(self, mock_system):
+        ctx = Context(dimensions={})
+        dim = Dimension("test", formula="__import__('os').system('echo test')")
+        result = dim.resolve(ctx)
+        mock_system.assert_not_called()
+        assert result is None
+
+
+class TestTypeUnionFixes:
+    """Test that isinstance() works correctly with type unions."""
+
+    def test_validate_positive_with_numbers(self):
+        assert validate_positive(5) is True
+        assert validate_positive(0) is False
+        assert validate_positive(-5) is False
+        assert validate_positive(5.5) is True
+        assert validate_positive(0.0) is False
+        assert validate_positive(-5.5) is False
+        assert validate_positive(float('inf')) is True
+        assert validate_positive(float('-inf')) is False
+
+    def test_validate_positive_with_tuples(self):
+        assert validate_positive((1, 2, 3)) is True
+        assert validate_positive((1.5, 2.5)) is True
+        assert validate_positive((1, 2.5, 3)) is True
+        assert validate_positive((1, 0, 3)) is False
+        assert validate_positive((1, -2, 3)) is False
+        assert validate_positive(()) is True
+
+    def test_validate_positive_with_wrong_types(self):
+        assert validate_positive("5") is False
+        assert validate_positive([1, 2, 3]) is False
+        assert validate_positive(None) is False
+        assert validate_positive({"x": 5}) is False
+
+    def test_validate_probability(self):
+        assert validate_probability(0.0) is True
+        assert validate_probability(0.5) is True
+        assert validate_probability(1.0) is True
+        assert validate_probability(-0.1) is False
+        assert validate_probability(1.1) is False
+
+    def test_validate_dimension(self):
+        assert validate_dimension(1) is True
+        assert validate_dimension(768) is True
+        assert validate_dimension(65536) is True
+        assert validate_dimension(0) is False
+        assert validate_dimension(-1) is False
+        assert validate_dimension(65537) is False
+
+
+class TestChoiceValidation:
+    """Test that choice validation includes type checking."""
+
+    def test_choices_with_consistent_types(self):
+        from energy_transformer.spec.primitives import param, Spec
+        from dataclasses import dataclass
+
+        @dataclass(frozen=True)
+        class TestSpec(Spec):
+            mode: str = param(default="auto", choices=["auto", "manual", "hybrid"])
+            size: int = param(default=1, choices=[1, 2, 4, 8])
+
+        spec = TestSpec(mode="manual", size=4)
+        assert spec.mode == "manual"
+        assert spec.size == 4
+
+    def test_choices_with_mixed_types_warns(self, caplog):
+        from energy_transformer.spec.primitives import param, Spec
+        from dataclasses import dataclass
+        import logging
+
+        logging.basicConfig(level=logging.WARNING)
+
+        @dataclass(frozen=True)
+        class BadSpec(Spec):
+            value: str | None = param(default="a", choices=["a", "b", None])
+
+        BadSpec(value=None)
+
+    def test_choices_type_mismatch_error(self):
+        from energy_transformer.spec.primitives import param, Spec, ValidationError
+        from dataclasses import dataclass
+
+        @dataclass(frozen=True)
+        class TestSpec(Spec):
+            size: int = param(choices=[1, 2, 4, 8])
+
+        with pytest.raises(ValidationError):
+            TestSpec(size="2")
+
+
+class TestIntegration:
+    """Integration tests combining multiple fixes."""
+
+    def test_complex_formula_with_validation(self):
+        from energy_transformer.spec.primitives import Context, Dimension
+
+        ctx = Context(dimensions={"embed_dim": 768, "num_heads": 12, "mlp_ratio": 4})
+
+        dim1 = Dimension("head_dim", formula="embed_dim / num_heads")
+        assert dim1.resolve(ctx) == 64
+
+        dim2 = Dimension("mlp_hidden", formula="embed_dim * mlp_ratio")
+        assert dim2.resolve(ctx) == 3072
+
+        dim3 = Dimension("exploit", formula="exec('x=1') or embed_dim")
+        assert dim3.resolve(ctx) is None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/verify_security.py
+++ b/verify_security.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""Verify the security fix works correctly."""
+
+from energy_transformer.spec.primitives import Dimension, Context
+
+# This should NOT print anything or execute code
+ctx = Context(dimensions={"x": 10})
+evil = Dimension("evil", formula="print('HACKED!') or x")
+result = evil.resolve(ctx)
+print(f"Evil formula result: {result}")
+
+# This should work correctly
+good = Dimension("good", formula="x * 2")
+result = good.resolve(ctx)
+print(f"Good formula result: {result}")

--- a/verify_types.py
+++ b/verify_types.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+"""Verify type union fixes work."""
+
+from energy_transformer.spec.library import validate_positive
+
+# These should all work without crashing
+print(f"validate_positive(5): {validate_positive(5)}")
+print(f"validate_positive(5.5): {validate_positive(5.5)}")
+print(f"validate_positive((2, 3)): {validate_positive((2, 3))}")
+print(f"validate_positive(-1): {validate_positive(-1)}")


### PR DESCRIPTION
## Summary
- replace eval() with safe formula parser
- fix isinstance union syntax
- warn about mixed choice types and check value type
- add comprehensive security and type tests
- bump version to 0.2.0-alpha1 and add SECURITY policy

## Testing
- `pytest -q tests/test_security_and_types.py`

------
https://chatgpt.com/codex/tasks/task_e_683a0c799e38832bbf4d96e2878e68c7