### PR TITLE
Optimize attention memory usage

### DIFF
--- a/energy_transformer/layers/attention.py
+++ b/energy_transformer/layers/attention.py
@@ -185,7 +185,9 @@ class MultiHeadEnergyAttention(BaseEnergyAttention):
         if b_k is not None or b_q is not None:
             bk = b_k if b_k is not None else torch.zeros_like(self.b_q)
             bq = b_q if b_q is not None else torch.zeros_like(self.b_k)
-            bias = torch.cat((bk.repeat(self.num_heads), bq.repeat(self.num_heads)))
+            bias = torch.cat(
+                (bk.repeat(self.num_heads), bq.repeat(self.num_heads))
+            )
         else:
             bias = None
 
@@ -197,24 +199,44 @@ class MultiHeadEnergyAttention(BaseEnergyAttention):
         # Aₕᴮᶜ = ∑ₐ Kₐₕᴮ·Qₐₕᶜ,     A ∈ ℝᴴˣᴺˣᴺ
         k = k.transpose(-3, -2)  # (..., H, N, Y)
         q = q.transpose(-3, -2)  # (..., H, N, Y)
-        a = torch.matmul(k, q.transpose(-1, -2))  # (..., H, N, N)
-        # TODO: avoid full N×N materialization
 
-        # Mask diagonal (self-token) entries if requested
-        if not include_diag:
-            # Efficiently fill diagonals without allocating a mask matrix
-            a.diagonal(dim1=-2, dim2=-1).fill_(float("-inf"))
+        # Compute logsumexp of the attention scores without materializing the
+        # full N×N matrix. For typical sequence lengths this matches the
+        # original behaviour, while for long sequences it avoids allocating a
+        # potentially huge attention matrix.
+        block_size = 512
+        if seq_len <= block_size:
+            a = torch.matmul(k, q.transpose(-1, -2))  # (..., H, N, N)
 
-        # Apply external attention mask if provided
-        if attn_mask is not None:
-            # Use additive masking (compatible with -inf values)
-            a = a + attn_mask  # shape: [..., H, N, N]
+            if not include_diag:
+                a.diagonal(dim1=-2, dim2=-1).fill_(float("-inf"))
 
-        # β·Aₕᴮᶜ - Scale attention matrix by temperature
-        βa = self.β * a  # shape: [..., H, N, N]
+            if attn_mask is not None:
+                a = a + attn_mask
 
-        # log(∑ᴮ exp(β·Aₕᴮᶜ)) - LogSumExp over keys dimension
-        lse = torch.logsumexp(βa, dim=-2)  # shape: [..., H, N]
+            βa = self.β * a
+            lse = torch.logsumexp(βa, dim=-2)
+        else:
+            lse_parts = []
+            for start in range(0, seq_len, block_size):
+                end = min(start + block_size, seq_len)
+                q_block = q[..., start:end, :]  # (..., H, B, Y)
+                a_block = torch.matmul(
+                    k, q_block.transpose(-1, -2)
+                )  # (..., H, N, B)
+
+                if not include_diag:
+                    idx = torch.arange(start, end, device=g.device)
+                    a_block[..., idx, idx - start] = float("-inf")
+
+                if attn_mask is not None:
+                    a_block = a_block + attn_mask[..., :, :, start:end]
+
+                βa_block = self.β * a_block
+                lse_block = torch.logsumexp(βa_block, dim=-2)
+                lse_parts.append(lse_block)
+
+            lse = torch.cat(lse_parts, dim=-1)
 
         # E^ATT = -(1/β)·∑ₕ₌₁ᴴ·∑ᶜ₌₁ᴺ·log(∑ᴮ exp(β·Aₕᴮᶜ))
         β_inv = 1.0 / self.β

--- a/tests/unit/layers/test_attention.py
+++ b/tests/unit/layers/test_attention.py
@@ -146,3 +146,22 @@ def test_attention_mask_broadcast() -> None:
     expanded_mask = mask.expand(1, 2, 3, 3)
     expected = _manual_energy(g, attn.w_k, attn.w_q, attn_mask=expanded_mask)
     assert torch.allclose(energy, expected, atol=1e-6)
+
+
+def test_attention_large_sequence_matches_manual() -> None:
+    torch.manual_seed(0)
+    n = 513
+    in_dim = 2
+    num_heads = 1
+    head_dim = 2
+    attn = MultiHeadEnergyAttention(
+        in_dim=in_dim,
+        num_heads=num_heads,
+        head_dim=head_dim,
+        beta=1.0,
+        bias=False,
+    )
+    g = torch.randn(1, n, in_dim)
+    energy = attn(g)
+    expected = _manual_energy(g, attn.w_k, attn.w_q)
+    assert torch.allclose(energy, expected, atol=1e-6)


### PR DESCRIPTION
## Summary
- avoid materializing the full N×N attention matrix for long sequences
- compute logsumexp in blocks
- add regression test for long-sequence path
- remove stray files in repo root

## Testing
- `pytest tests/unit/layers/test_attention.py::test_attention_large_sequence_matches_manual -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683a3dc4955c832b8dec227c7477bf14