### PR TITLE
Fix lint and typing issues

### DIFF
--- a/energy_transformer/__init__.py
+++ b/energy_transformer/__init__.py
@@ -15,8 +15,7 @@ For visualization and optional features:
 >>> from energy_transformer.models import viet_base  # Loads full models
 """
 
-import sys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 __version__ = "0.3.1"
 __author__ = "Ayan Das <bvits@riseup.net>"
@@ -43,24 +42,24 @@ _LAZY_IMPORTS = {
 
 # For static type checking, import everything
 if TYPE_CHECKING:  # pragma: no cover
-    from .models import EnergyTransformer
+    from .models import EnergyTransformer  # noqa: F401
     from .spec import (
-        Context,
-        RealisationError,
-        Spec,
-        ValidationError,
-        cond,
-        configure_realisation,
-        loop,
-        parallel,
-        realise,
-        register,
-        seq,
-        visualize,
+        Context,  # noqa: F401
+        RealisationError,  # noqa: F401
+        Spec,  # noqa: F401
+        ValidationError,  # noqa: F401
+        cond,  # noqa: F401
+        configure_realisation,  # noqa: F401
+        loop,  # noqa: F401
+        parallel,  # noqa: F401
+        realise,  # noqa: F401
+        register,  # noqa: F401
+        seq,  # noqa: F401
+        visualize,  # noqa: F401
     )
 
 
-def __getattr__(name: str):
+def __getattr__(name: str) -> Any:
     """Lazy load modules and attributes.
 
     This implements PEP 562 for lazy loading. Attributes are only
@@ -90,7 +89,7 @@ def __getattr__(name: str):
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-def __dir__():
+def __dir__() -> list[str]:
     """List available attributes for tab completion."""
     return list(_LAZY_IMPORTS.keys()) + [
         "__version__",

--- a/energy_transformer/spec/__init__.py
+++ b/energy_transformer/spec/__init__.py
@@ -38,7 +38,7 @@ Example
 """
 
 from collections.abc import Callable
-from typing import TypeAlias
+from typing import Any, TypeAlias
 
 # Combinators
 from .combinators import (
@@ -130,7 +130,7 @@ _LIBRARY_SPECS = [
 ]
 
 
-def __getattr__(name: str):
+def __getattr__(name: str) -> Any:
     """Lazy load library specifications."""
     if name in _LIBRARY_SPECS:
         from . import library
@@ -214,7 +214,7 @@ SpecLike: TypeAlias = Spec | Sequential | Parallel | Conditional | Residual
 
 # NO GLOBAL CONFIGURATION ON IMPORT!
 # Users must explicitly configure if they want non-defaults
-def initialize_defaults():
+def initialize_defaults() -> None:
     """Initialize default configuration.
 
     This must be called explicitly by users who want default settings.
@@ -280,44 +280,44 @@ def export_patterns() -> dict[str, Callable[..., Spec]]:
     """Return common architectural patterns ready to use."""
     from . import library
 
-    PatchEmbedSpec = library.PatchEmbedSpec
-    CLSTokenSpec = library.CLSTokenSpec
-    PosEmbedSpec = library.PosEmbedSpec
-    ETBlockSpec = library.ETBlockSpec
-    LayerNormSpec = library.LayerNormSpec
-    MHEASpec = library.MHEASpec
-    HNSpec = library.HNSpec
+    patch_embed_spec = library.PatchEmbedSpec
+    cls_token_spec = library.CLSTokenSpec
+    pos_embed_spec = library.PosEmbedSpec
+    et_block_spec = library.ETBlockSpec
+    layer_norm_spec = library.LayerNormSpec
+    mheaspec = library.MHEASpec
+    hnspec = library.HNSpec
 
     return {
         "vit_tiny": lambda **kwargs: seq(
-            PatchEmbedSpec(
+            patch_embed_spec(
                 img_size=224, patch_size=16, embed_dim=192, **kwargs
             ),
-            CLSTokenSpec(),
-            PosEmbedSpec(include_cls=True),
+            cls_token_spec(),
+            pos_embed_spec(include_cls=True),
             loop(
-                ETBlockSpec(
-                    attention=MHEASpec(num_heads=3, head_dim=64),
-                    hopfield=HNSpec(),
+                et_block_spec(
+                    attention=mheaspec(num_heads=3, head_dim=64),
+                    hopfield=hnspec(),
                 ),
                 times=12,
             ),
-            LayerNormSpec(),
+            layer_norm_spec(),
         ),
         "vit_base": lambda **kwargs: seq(
-            PatchEmbedSpec(
+            patch_embed_spec(
                 img_size=224, patch_size=16, embed_dim=768, **kwargs
             ),
-            CLSTokenSpec(),
-            PosEmbedSpec(include_cls=True),
+            cls_token_spec(),
+            pos_embed_spec(include_cls=True),
             loop(
-                ETBlockSpec(
-                    attention=MHEASpec(num_heads=12, head_dim=64),
-                    hopfield=HNSpec(),
+                et_block_spec(
+                    attention=mheaspec(num_heads=12, head_dim=64),
+                    hopfield=hnspec(),
                 ),
                 times=12,
             ),
-            LayerNormSpec(),
+            layer_norm_spec(),
         ),
     }
 

--- a/energy_transformer/spec/combinators.py
+++ b/energy_transformer/spec/combinators.py
@@ -282,17 +282,17 @@ class Parallel(Spec):
 
         elif self.merge == "concat":
             if self.merge_dim:
-                dims = []
+                concat_dims: list[int] = []
                 for _i, branch in enumerate(self.branches):
                     branch_ctx = branch.apply_context(context.child())
                     dim_value = branch_ctx.get_dim(self.merge_dim)
                     if dim_value:
-                        dims.append(dim_value)
+                        concat_dims.append(dim_value)
 
-                if dims and max(dims) > min(dims) * 10:
+                if concat_dims and max(concat_dims) > min(concat_dims) * 10:
                     issues.append(
                         f"Warning: Large dimension disparity in concat merge: "
-                        f"min={min(dims)}, max={max(dims)}"
+                        f"min={min(concat_dims)}, max={max(concat_dims)}"
                     )
 
         # Validate weights if provided

--- a/energy_transformer/spec/debug.py
+++ b/energy_transformer/spec/debug.py
@@ -1,6 +1,7 @@
 """Debug utilities for the realisation system."""
 
 import logging
+from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import Any
 
@@ -13,7 +14,7 @@ def debug_realisation(
     break_on_error: bool = False,
     trace_cache: bool = True,
     trace_imports: bool = True,
-):
+) -> Iterator[None]:
     """Context manager for debugging realisation issues."""
     logger = logging.getLogger("energy_transformer.spec")
     old_level = logger.level
@@ -46,8 +47,8 @@ def debug_realisation(
             logger.debug(f"Cache PUT: {spec.__class__.__name__}")
             original_put(spec, context, module)
 
-        _config.cache.get = traced_get
-        _config.cache.put = traced_put
+        _config.cache.get = traced_get  # type: ignore[method-assign]
+        _config.cache.put = traced_put  # type: ignore[method-assign]
 
     try:
         yield
@@ -63,8 +64,8 @@ def debug_realisation(
         _config.warnings = old_warnings
 
         if trace_cache:
-            _config.cache.get = original_get
-            _config.cache.put = original_put
+            _config.cache.get = original_get  # type: ignore[method-assign]
+            _config.cache.put = original_put  # type: ignore[method-assign]
 
 
 def inspect_cache_stats() -> None:

--- a/energy_transformer/spec/primitives.py
+++ b/energy_transformer/spec/primitives.py
@@ -150,6 +150,7 @@ class Dimension:
         for match in token_regex.finditer(formula):
             kind = match.lastgroup
             value = match.group()
+            assert kind is not None
             if kind == "WHITESPACE":
                 continue
             elif kind == "INVALID":
@@ -225,15 +226,15 @@ class Dimension:
 
         elif token_type == "LPAREN":
             pos += 1  # Skip '('
-            value, pos = self._parse_expression(tokens, pos, variables)
+            expr_value, pos = self._parse_expression(tokens, pos, variables)
             if pos >= len(tokens) or tokens[pos][0] != "RPAREN":
                 raise ValueError("Missing closing parenthesis")
-            return value, pos + 1  # Skip ')'
+            return expr_value, pos + 1  # Skip ')'
 
         elif token_type == "MINUS":
             pos += 1  # Skip unary minus
-            value, pos = self._parse_factor(tokens, pos, variables)
-            return -value, pos
+            factor_val, pos = self._parse_factor(tokens, pos, variables)
+            return -factor_val, pos
 
         else:
             raise ValueError(f"Unexpected token: {token_value}")


### PR DESCRIPTION
## Summary
- silence unused imports and add type hints
- correct export pattern variable names
- handle optional dimensions more safely
- add typing improvements and clarify debug helpers
- adjust graph realisation logic
- keep ruff and mypy happy

## Testing
- `poetry run ruff check .`
- `poetry run ruff format --check .`
- `poetry run mypy .`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683bf8646ff8832b8e8d017d1441ca44