### PR TITLE
test: improve coverage for spec modules

### DIFF
--- a/tests/unit/spec/test_api_extra.py
+++ b/tests/unit/spec/test_api_extra.py
@@ -1,0 +1,104 @@
+"""Additional tests for public specification API.
+
+These tests cover the convenience functions and utilities exposed in
+:mod:`energy_transformer.spec.__init__` that were previously
+uncovered by the main test suite.
+"""
+
+from __future__ import annotations
+
+import io
+from contextlib import redirect_stdout
+from dataclasses import dataclass
+from unittest.mock import patch
+
+import pytest
+
+import energy_transformer.spec as et_spec
+from energy_transformer.spec import Spec, requires
+
+
+def test_getattr_lazy_loading() -> None:
+    """``__getattr__`` lazily loads library specifications."""
+    cls = getattr(et_spec, "LayerNormSpec")
+    from energy_transformer.spec import library
+
+    assert cls is library.LayerNormSpec
+
+
+def test_getattr_unknown() -> None:
+    """Accessing an unknown attribute raises :class:`AttributeError`."""
+    with pytest.raises(AttributeError):
+        getattr(et_spec, "DoesNotExist")
+
+
+def test_initialize_defaults_calls_configure() -> None:
+    """``initialize_defaults`` should forward defaults to ``configure_realisation``."""
+    with patch("energy_transformer.spec.realise.configure_realisation") as conf:
+        et_spec.initialize_defaults()
+        conf.assert_called_once()
+        args, kwargs = conf.call_args
+        assert kwargs["cache"].max_size == 128
+        assert kwargs["strict"] is True
+        assert kwargs["warnings"] is True
+        assert kwargs["auto_import"] is True
+        assert kwargs["optimizations"] is True
+        assert kwargs["max_recursion"] == 100
+
+
+def test_quickstart_prints_guide() -> None:
+    """``quickstart`` only prints a help message."""
+    out = io.StringIO()
+    with redirect_stdout(out):
+        et_spec.quickstart()
+    text = out.getvalue()
+    assert "Energy Transformer Specification System" in text
+
+
+def test_export_patterns_create_specs() -> None:
+    """``export_patterns`` returns callable constructors for patterns."""
+    patterns = et_spec.export_patterns()
+    tiny = patterns["vit_tiny"]()
+    base = patterns["vit_base"]()
+    assert isinstance(tiny, Spec)
+    assert isinstance(base, Spec)
+
+
+@dataclass(frozen=True)
+@requires("foo")
+class NeedsFooSpec(Spec):
+    """Spec requiring a dimension that will be missing."""
+
+    pass
+
+
+def test_validate_spec_tree_detects_issue() -> None:
+    """``validate_spec_tree`` returns issues for invalid trees."""
+    issues = et_spec.validate_spec_tree(NeedsFooSpec())
+    assert issues and "foo" in issues[0]
+
+
+def test_validate_spec_tree_verbose(capsys) -> None:
+    """Verbose mode prints information and still returns issues."""
+    issues = et_spec.validate_spec_tree(NeedsFooSpec(), verbose=True)
+    captured = capsys.readouterr()
+    assert "Validating" in captured.out
+    assert issues
+
+
+def test_validate_spec_tree_verbose_no_issue(capsys) -> None:
+    """Validation prints success message when no issues are found."""
+    spec = et_spec.seq(et_spec.IdentitySpec(), et_spec.IdentitySpec())
+    issues = et_spec.validate_spec_tree(spec, verbose=True)
+    out = capsys.readouterr().out
+    assert "No issues found" in out
+    assert issues == []
+
+
+def test_benchmark_realisation_runs() -> None:
+    """``benchmark_realisation`` executes realisation multiple times."""
+    spec = et_spec.IdentitySpec()
+    stats = et_spec.benchmark_realisation(spec, iterations=2)
+    assert stats["iterations"] == 2
+    assert stats["total"] > 0
+

--- a/tests/unit/spec/test_debug.py
+++ b/tests/unit/spec/test_debug.py
@@ -1,0 +1,52 @@
+"""Tests for :mod:`energy_transformer.spec.debug` utilities."""
+
+from __future__ import annotations
+
+import logging
+from io import StringIO
+from contextlib import redirect_stdout
+
+import pytest
+import torch.nn as nn
+
+from energy_transformer.spec.debug import (
+    clear_cache,
+    debug_realisation,
+    inspect_cache_stats,
+)
+from energy_transformer.spec.realise import ModuleCache, _config
+from energy_transformer.spec import Context
+from tests.unit.spec.test_realise import SimpleSpec
+
+
+def test_debug_realisation_traces_cache(caplog) -> None:
+    """Cache operations are logged when tracing is enabled."""
+    cache = ModuleCache()
+    _config.cache = cache
+
+    caplog.set_level(logging.DEBUG)
+    with debug_realisation(trace_cache=True):
+        _config.cache.get(SimpleSpec(), Context())
+        _config.cache.put(SimpleSpec(), Context(), nn.Identity())
+
+    assert any("Cache MISS" in rec.message for rec in caplog.records)
+    assert any("Cache PUT" in rec.message for rec in caplog.records)
+
+
+def test_inspect_and_clear_cache_output(capsys) -> None:
+    """``inspect_cache_stats`` prints stats and ``clear_cache`` empties cache."""
+    cache = ModuleCache()
+    _config.cache = cache
+    cache.put(SimpleSpec(), Context(), nn.Identity())
+
+    with redirect_stdout(StringIO()) as buf:
+        inspect_cache_stats()
+        output = buf.getvalue()
+        assert "Cache Statistics" in output
+        assert "Size: 1" in output
+
+    with redirect_stdout(StringIO()) as buf:
+        clear_cache()
+        assert "Cache cleared" in buf.getvalue()
+    assert len(cache._cache) == 0
+

--- a/tests/unit/spec/test_primitives_extra.py
+++ b/tests/unit/spec/test_primitives_extra.py
@@ -1,0 +1,42 @@
+"""Extra tests for primitives focusing on dimension resolution and validation."""
+
+from __future__ import annotations
+
+import pytest
+from dataclasses import dataclass
+
+from energy_transformer.spec.primitives import Dimension, ValidationError, REQUIRED
+from energy_transformer.spec.primitives import Context, Spec, param
+
+
+class TestDimensionResolve:
+    """Tests for :class:`Dimension` formula evaluation."""
+
+    def test_resolve_formula(self) -> None:
+        ctx = Context(dimensions={"a": 2, "b": 8})
+        dim = Dimension("d", formula="a * 2 + b / 4")
+        assert dim.resolve(ctx) == 6
+
+    def test_resolve_errors_return_none(self) -> None:
+        ctx = Context(dimensions={"a": 1})
+        # Division by zero
+        dim = Dimension("d", formula="a / 0")
+        assert dim.resolve(ctx) is None
+        # Unknown variable
+        dim2 = Dimension("d", formula="missing + 1")
+        assert dim2.resolve(ctx) is None
+        # Mismatched parentheses
+        dim3 = Dimension("d", formula="(a + 2")
+        assert dim3.resolve(ctx) is None
+
+
+def test_required_parameter_validation() -> None:
+    """Missing required parameters raise :class:`ValidationError`."""
+
+    @dataclass(frozen=True)
+    class ReqSpec(Spec):
+        value: int = param()
+
+    with pytest.raises(ValidationError):
+        ReqSpec(value=REQUIRED)
+

--- a/tests/unit/spec/test_realise_extra.py
+++ b/tests/unit/spec/test_realise_extra.py
@@ -1,0 +1,69 @@
+"""Additional tests for realisation utilities and modules."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import pytest
+
+from energy_transformer.spec.realise import ModuleCache, GraphModule
+from energy_transformer.spec import Context
+from energy_transformer.spec import library
+
+
+def test_module_cache_etblock_key() -> None:
+    """ETBlockSpec instances use their id in cache keys."""
+    cache = ModuleCache()
+    spec = library.ETBlockSpec(
+        attention=library.MHEASpec(num_heads=1, head_dim=16),
+        hopfield=library.HNSpec(),
+    )
+    key = cache._make_key(spec, Context())
+    assert key[0] == "nocache" and key[1] == id(spec)
+
+
+def test_debug_realisation_break_on_error(monkeypatch) -> None:
+    """``debug_realisation`` invokes ``pdb.post_mortem`` when requested."""
+    from energy_transformer.spec.debug import debug_realisation
+    called = {}
+    monkeypatch.setattr("pdb.post_mortem", lambda: called.setdefault("pdb", True))
+    with pytest.raises(RuntimeError):
+        with debug_realisation(break_on_error=True):
+            raise RuntimeError("boom")
+    assert called.get("pdb")
+
+
+def test_validate_spec_tree_verbose_no_issues(capsys) -> None:
+    """Verbose validation prints success and recurses."""
+    import energy_transformer.spec as et_spec
+
+    spec = et_spec.seq(et_spec.IdentitySpec(), et_spec.IdentitySpec())
+    issues = et_spec.validate_spec_tree(spec, verbose=True)
+    out = capsys.readouterr().out
+    assert "No issues found" in out
+    assert issues == []
+
+
+def test_graph_module_errors() -> None:
+    """GraphModule raises helpful errors on invalid graphs."""
+    nodes = {"a": nn.Identity(), "b": nn.Identity()}
+    # Cycle detection
+    gm_cycle = GraphModule(nodes, [("a", "b"), ("b", "a")], inputs=["x"], outputs=["a"])
+    with pytest.raises(RuntimeError, match="cycles"):
+        gm_cycle(torch.randn(1, 1))
+
+    # Missing input value
+    gm_missing = GraphModule(nodes, [("a", "b")], inputs=["x"], outputs=["b"])
+    with pytest.raises(RuntimeError, match="no inputs"):
+        gm_missing(torch.randn(1, 1))
+
+
+def test_apply_edge_transform_variants() -> None:
+    """``_apply_edge_transform`` handles known and unknown transforms."""
+    gm = GraphModule({}, [], [], [])
+    t = torch.ones(1)
+    assert torch.allclose(gm._apply_edge_transform(t, "relu"), torch.relu(t))
+    assert torch.allclose(gm._apply_edge_transform(t, "sigmoid"), torch.sigmoid(t))
+    with pytest.raises(ValueError):
+        gm._apply_edge_transform(t, "unknown")
+


### PR DESCRIPTION
## Summary
- add tests covering `energy_transformer.spec` convenience API
- add debug utility tests
- add additional coverage for primitives and realiser helpers

## Testing
- `pytest --cov=energy_transformer --cov-report=term --cov-report=json -q`

------
https://chatgpt.com/codex/tasks/task_e_683c12e78b70832b8c069cc3b0d21c08