### PR TITLE
Fix security and thread safety

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,16 +46,21 @@ def simple_image_batch():
 @pytest.fixture(autouse=True)
 def reset_global_state():
     """Reset global state before each test."""
-    from energy_transformer.spec.realise import _config
+    from energy_transformer.spec.realise import _get_config, _thread_local
 
-    _config.cache.clear()
-    _config.strict = True
-    _config.warnings = True
-    _config.auto_import = True  # Fixed typo
-    _config.optimizations = True
-    _config.max_recursion = 100  # Fixed typo
+    if hasattr(_thread_local, "config"):
+        delattr(_thread_local, "config")
+    config = _get_config()
+    config.cache.clear()
+    config.strict = True
+    config.warnings = True
+    config.auto_import = True
+    config.optimizations = True
+    config.max_recursion = 100
     yield
-    _config.cache.clear()
+    if hasattr(_thread_local, "config"):
+        _thread_local.config.cache.clear()
+        delattr(_thread_local, "config")
 
 
 @pytest.fixture

--- a/tests/functional/test_import_behavior.py
+++ b/tests/functional/test_import_behavior.py
@@ -234,21 +234,21 @@ print("SUCCESS")
         code = """
 # Import and check for side effects
 import energy_transformer.spec
-from energy_transformer.spec.realise import _config
+from energy_transformer.spec.realise import _get_config
 
 # Get initial state
-initial_cache_enabled = _config.cache.enabled
-initial_cache_size = _config.cache.max_size
-initial_strict = _config.strict
+initial_cache_enabled = _get_config().cache.enabled
+initial_cache_size = _get_config().cache.max_size
+initial_strict = _get_config().strict
 
 # Import everything
 from energy_transformer import *
 from energy_transformer.spec import *
 
 # Check if state changed
-assert _config.cache.enabled == initial_cache_enabled, "cache.enabled changed on import!"
-assert _config.cache.max_size == initial_cache_size, "cache.max_size changed on import!"
-assert _config.strict == initial_strict, "strict mode changed on import!"
+assert _get_config().cache.enabled == initial_cache_enabled, "cache.enabled changed on import!"
+assert _get_config().cache.max_size == initial_cache_size, "cache.max_size changed on import!"
+assert _get_config().strict == initial_strict, "strict mode changed on import!"
 
 print("SUCCESS: No side effects detected")
 """

--- a/tests/integration/test_cache_keys.py
+++ b/tests/integration/test_cache_keys.py
@@ -16,7 +16,7 @@ from energy_transformer.spec import (
 )
 from energy_transformer.spec.realise import (
     ModuleCache,
-    _config,
+    _get_config,
 )
 
 pytestmark = pytest.mark.integration
@@ -82,7 +82,6 @@ class TestCacheKeyGeneration:
         ctx = Context(metadata={"circular": circular_dict})
         key = cache._make_key(spec, ctx)
         assert key is not None
-        assert "<cycle:" in str(key)
 
     def test_cache_invalidation_on_version_change(self):
         cache = ModuleCache()
@@ -137,17 +136,17 @@ class TestCacheKeyGeneration:
 
         spec = IdentitySpec()
 
-        _config.cache.clear()
-        _config.cache._hit_count = 0
-        _config.cache._miss_count = 0
+        _get_config().cache.clear()
+        _get_config().cache._hit_count = 0
+        _get_config().cache._miss_count = 0
 
         model1 = realise(spec, context=ctx1)
-        assert _config.cache._hit_count == 0
-        assert _config.cache._miss_count > 0
+        assert _get_config().cache._hit_count == 0
+        assert _get_config().cache._miss_count > 0
 
-        miss_after_first = _config.cache._miss_count
+        miss_after_first = _get_config().cache._miss_count
 
         model2 = realise(spec, context=ctx2)
-        assert _config.cache._hit_count >= 1
-        assert _config.cache._miss_count == miss_after_first
+        assert _get_config().cache._hit_count >= 1
+        assert _get_config().cache._miss_count == miss_after_first
         assert model1 is model2

--- a/tests/regression/test_cache_restoration.py
+++ b/tests/regression/test_cache_restoration.py
@@ -22,7 +22,7 @@ from energy_transformer.spec.primitives import SpecMeta
 from energy_transformer.spec.realise import (
     ModuleCache,
     Realiser,
-    _config,
+    _get_config,
     register,
 )
 
@@ -53,7 +53,7 @@ class TestCacheStateRestoration:
 
     def test_cache_restored_after_exception(self):
         configure_realisation(cache=ModuleCache(enabled=True))
-        assert _config.cache.enabled
+        assert _get_config().cache.enabled
 
         @register(SimpleSpec)
         def realise_simple(_spec, _context):
@@ -83,12 +83,12 @@ class TestCacheStateRestoration:
         with pytest.raises(RealisationError):
             realise(loop_spec)
 
-        assert _config.cache.enabled
+        assert _get_config().cache.enabled
 
         simple = SimpleSpec()
         realise(simple)
         realise(simple)
-        assert _config.cache.hit_rate > 0
+        assert _get_config().cache.hit_rate > 0
         SpecMeta._realisers.pop(SimpleSpec, None)
 
     def test_cache_restored_with_nested_errors(self):
@@ -118,13 +118,13 @@ class TestCacheStateRestoration:
             ),
         )
 
-        initial_state = _config.cache.enabled
+        initial_state = _get_config().cache.enabled
         with pytest.raises(RealisationError):
             realise(nested)
-        assert _config.cache.enabled == initial_state
+        assert _get_config().cache.enabled == initial_state
 
     def test_multiple_cache_errors_handled(self):
-        with patch.object(_config, "cache") as mock_cache:
+        with patch.object(_get_config(), "cache") as mock_cache:
             type(mock_cache).enabled = property(
                 lambda _self: True,
                 lambda _self, _value: (_ for _ in ()).throw(
@@ -158,7 +158,7 @@ class TestCacheStateRestoration:
         )
         from energy_transformer.spec.realise import (
             ModuleCache,
-            _config,
+            _get_config,
             register,
         )
 
@@ -177,7 +177,7 @@ class TestCacheStateRestoration:
             return nn.Identity()
 
         configure_realisation(cache=ModuleCache(enabled=True))
-        initial_state = _config.cache.enabled
+        initial_state = _get_config().cache.enabled
         assert initial_state
 
         with pytest.raises(
@@ -188,7 +188,7 @@ class TestCacheStateRestoration:
                 loop(FailingSpec(), times=3, unroll=True, share_weights=False),
             )
 
-        assert _config.cache.enabled == initial_state, (
+        assert _get_config().cache.enabled == initial_state, (
             "Cache state was not restored!"
         )
 

--- a/tests/regression/test_recursion_fixes.py
+++ b/tests/regression/test_recursion_fixes.py
@@ -22,7 +22,7 @@ from energy_transformer.spec import (
 from energy_transformer.spec.primitives import SpecMeta
 from energy_transformer.spec.realise import (
     Realiser,
-    _config,
+    _get_config,
     register,
 )
 
@@ -70,7 +70,7 @@ class TestRecursionDepth:
         model2 = realise(deep_spec, context=ctx)
         assert model2 is not None
 
-        assert _config.cache.hit_rate > 0
+        assert _get_config().cache.hit_rate > 0
 
     def test_recursion_error_includes_context(self):
         configure_realisation(max_recursion=3, optimizations=False)
@@ -125,7 +125,7 @@ class TestRecursionDepth:
         """Test exact behavior from verify_recursion_fix.py."""
         from energy_transformer.spec import configure_realisation, realise, seq
         from energy_transformer.spec.library import IdentitySpec
-        from energy_transformer.spec.realise import _config
+        from energy_transformer.spec.realise import _get_config
 
         configure_realisation(max_recursion=5)
         deep_model_spec = seq(*[IdentitySpec() for _ in range(20)])
@@ -133,10 +133,10 @@ class TestRecursionDepth:
         model1 = realise(deep_model_spec)
         assert model1 is not None, "First realisation should succeed"
 
-        initial_hits = _config.cache._hit_count
+        initial_hits = _get_config().cache._hit_count
         model2 = realise(deep_model_spec)
         assert model2 is not None, "Second realisation should succeed"
 
-        final_hits = _config.cache._hit_count
+        final_hits = _get_config().cache._hit_count
         assert final_hits > initial_hits, "Cache should have been used"
-        assert _config.cache.hit_rate > 0, "Hit rate should be positive"
+        assert _get_config().cache.hit_rate > 0, "Hit rate should be positive"

--- a/tests/unit/spec/test_cache.py
+++ b/tests/unit/spec/test_cache.py
@@ -1,0 +1,36 @@
+from dataclasses import dataclass
+
+from energy_transformer.spec import Context, Sequential, Spec, param
+from energy_transformer.spec.realise import ModuleCache
+
+
+@dataclass(frozen=True)
+class DummySpec(Spec):
+    size: int = param(default=1)
+
+
+def test_simplified_cache_keys():
+    cache = ModuleCache()
+    simple_spec = DummySpec(size=16)
+    key1 = cache._make_key(simple_spec, Context())
+    assert isinstance(key1, tuple)
+    assert len(key1) == 2
+    assert isinstance(key1[0], str)
+    assert isinstance(key1[1], str)
+
+    complex_spec = Sequential(
+        [
+            DummySpec(size=32),
+            DummySpec(size=64),
+            Sequential(
+                [
+                    DummySpec(size=128),
+                    DummySpec(size=256),
+                ]
+            ),
+        ]
+    )
+    key2 = cache._make_key(complex_spec, Context())
+    assert isinstance(key2, tuple)
+    assert len(key2) == 2
+    assert key1 != key2

--- a/tests/unit/spec/test_debug.py
+++ b/tests/unit/spec/test_debug.py
@@ -15,7 +15,7 @@ from energy_transformer.spec.debug import (
     debug_realisation,
     inspect_cache_stats,
 )
-from energy_transformer.spec.realise import ModuleCache, _config
+from energy_transformer.spec.realise import ModuleCache, _get_config
 from tests.unit.spec.test_realise import SimpleSpec
 
 pytestmark = pytest.mark.unit
@@ -24,12 +24,12 @@ pytestmark = pytest.mark.unit
 def test_debug_realisation_traces_cache(caplog) -> None:
     """Cache operations are logged when tracing is enabled."""
     cache = ModuleCache()
-    _config.cache = cache
+    _get_config().cache = cache
 
     caplog.set_level(logging.DEBUG)
     with debug_realisation(trace_cache=True):
-        _config.cache.get(SimpleSpec(), Context())
-        _config.cache.put(SimpleSpec(), Context(), nn.Identity())
+        _get_config().cache.get(SimpleSpec(), Context())
+        _get_config().cache.put(SimpleSpec(), Context(), nn.Identity())
 
     assert any("Cache MISS" in rec.message for rec in caplog.records)
     assert any("Cache PUT" in rec.message for rec in caplog.records)
@@ -39,7 +39,7 @@ def test_debug_realisation_traces_cache(caplog) -> None:
 def test_inspect_and_clear_cache_output() -> None:
     """``inspect_cache_stats`` prints stats and ``clear_cache`` empties cache."""
     cache = ModuleCache()
-    _config.cache = cache
+    _get_config().cache = cache
     cache.put(SimpleSpec(), Context(), nn.Identity())
 
     with redirect_stdout(StringIO()) as buf:

--- a/tests/unit/spec/test_realise.py
+++ b/tests/unit/spec/test_realise.py
@@ -994,9 +994,9 @@ class TestPublicAPI:
             size: int = param(default=64)  # noqa: RUF009
 
         # Clear any potential cached modules
-        from energy_transformer.spec.realise import _config
+        from energy_transformer.spec.realise import _get_config
 
-        _config.cache.clear()
+        _get_config().cache.clear()
 
         @register(UniqueTestSpec)
         def my_realiser(spec, _context):

--- a/tests/unit/spec/test_realise_security.py
+++ b/tests/unit/spec/test_realise_security.py
@@ -1,0 +1,46 @@
+"""Test security fixes in realise module."""
+
+import builtins
+
+import pytest
+import torch
+
+from energy_transformer.spec.realise import GraphModule
+
+
+class TestGraphModuleSecurity:
+    """Test that GraphModule transformations are secure."""
+
+    def test_edge_transform_no_eval(self, monkeypatch):
+        called = False
+
+        def fake_eval(_expr):
+            nonlocal called
+            called = True
+            raise AssertionError("eval called")
+
+        monkeypatch.setattr(builtins, "eval", fake_eval)
+        gm = GraphModule({}, [], [], [])
+        out = gm._apply_edge_transform(torch.arange(5), "[0]")
+        assert out.item() == 0
+        assert not called
+
+    def test_safe_indexing(self):
+        gm = GraphModule({}, [], [], [])
+        t = torch.arange(10)
+        assert torch.equal(gm._apply_edge_transform(t, "[2]"), t[2])
+        assert torch.equal(gm._apply_edge_transform(t, "[1:4]"), t[1:4])
+        assert torch.equal(gm._apply_edge_transform(t, "[...]"), t[...])
+        assert torch.equal(gm._apply_edge_transform(t, "detach"), t.detach())
+
+    def test_malicious_transform_rejected(self):
+        gm = GraphModule({}, [], [], [])
+        dangerous_inputs = [
+            "__import__('os').system('ls')",
+            "exec('print(1)')",
+            "eval('1+1')",
+            "[__import__('os')]",
+        ]
+        for inp in dangerous_inputs:
+            with pytest.raises(ValueError, match="Unknown|Unsupported|Invalid"):
+                gm._apply_edge_transform(torch.arange(3), inp)

--- a/tests/unit/spec/test_thread_safety.py
+++ b/tests/unit/spec/test_thread_safety.py
@@ -1,0 +1,84 @@
+"""Test thread safety of realisation system."""
+
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from energy_transformer.spec import configure_realisation, realise, Context
+from dataclasses import dataclass
+
+from torch import nn
+
+from energy_transformer.spec import ModuleCache, param, register, Spec
+
+
+@dataclass(frozen=True)
+class ThreadSpec(Spec):
+    hidden: int = param(default=1)
+
+
+@register(ThreadSpec)
+def realise_simple(spec: ThreadSpec, _context: Context) -> nn.Linear:
+    return nn.Linear(spec.hidden, spec.hidden)
+
+
+class TestThreadSafety:
+    """Test that the realisation system is thread-safe."""
+
+    def test_concurrent_realisation(self):
+        num_threads = 10
+        num_specs_per_thread = 50
+
+        def worker(thread_id: int):
+            results = []
+            configure_realisation(
+                cache=ModuleCache(enabled=True), strict=bool(thread_id % 2)
+            )
+            for i in range(num_specs_per_thread):
+                spec = ThreadSpec(hidden=thread_id * 10 + i + 1)
+                module = realise(spec)
+                results.append((thread_id, i, module))
+            return results
+
+        with ThreadPoolExecutor(max_workers=num_threads) as executor:
+            futures = [executor.submit(worker, i) for i in range(num_threads)]
+            all_results = []
+            for future in as_completed(futures):
+                all_results.extend(future.result())
+
+        assert len(all_results) == num_threads * num_specs_per_thread
+        for thread_id, spec_id, module in all_results:
+            expected_in = thread_id * 10 + spec_id + 1
+            assert isinstance(module, nn.Linear)
+            assert module.in_features == expected_in
+
+    def test_config_isolation(self):
+        barrier = threading.Barrier(2)
+        results = {}
+
+        def worker1():
+            configure_realisation(strict=True, warnings=False)
+            barrier.wait()
+            time.sleep(0.1)
+            from energy_transformer.spec.realise import _get_config
+
+            config = _get_config()
+            results["worker1"] = (config.strict, config.warnings)
+
+        def worker2():
+            configure_realisation(strict=False, warnings=True)
+            barrier.wait()
+            from energy_transformer.spec.realise import _get_config
+
+            config = _get_config()
+            results["worker2"] = (config.strict, config.warnings)
+
+        t1 = threading.Thread(target=worker1)
+        t2 = threading.Thread(target=worker2)
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        assert results["worker1"] == (True, False)
+        assert results["worker2"] == (False, True)


### PR DESCRIPTION
## Summary
- remove `eval` usage with safe tensor transforms
- use thread-local configuration
- simplify cache keys with hashing
- update tests and add new ones for security and thread safety

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy .`
- `pytest -q`
- `pytest tests/unit/spec/test_realise_security.py -v`
- `pytest tests/unit/spec/test_thread_safety.py -v`
- `pytest tests/unit/spec/test_cache.py -v`
- `python scripts/run_mutation_tests.py --files energy_transformer/spec/realise.py`


------
https://chatgpt.com/codex/tasks/task_e_683c8b78c87c832bb638969c418f1cd1