### PR TITLE
Enable full Energy Transformer realisation

### DIFF
--- a/docs/spec_realisation.md
+++ b/docs/spec_realisation.md
@@ -1,0 +1,40 @@
+# Specification Realisation System
+
+## Overview
+
+The Energy Transformer uses a specification system that separates model
+architecture definition (specs) from concrete implementations. A spec describes
+what to build and the realiser converts it into PyTorch modules.
+
+## Core Components
+
+### Specifications
+- **ETBlockSpec**: Energy Transformer block specification
+- **MHEASpec**: Multi-Head Energy Attention specification
+- **HNSpec**: Hopfield Network specification
+- **SHNSpec**: Simplicial Hopfield Network specification
+
+### Realisation
+Specifications are converted to modules using registered realisers or the
+auto-import mechanism.
+
+```python
+spec = MHEASpec(num_heads=8, head_dim=64)
+module = realise(spec, embed_dim=512)
+```
+
+For composite specs like `ETBlockSpec`, a custom realiser constructs the full
+`EnergyTransformer`:
+
+```python
+@register(ETBlockSpec)
+def realise_et_block(spec, context):
+    attention = realise(spec.attention, context)
+    hopfield = realise(spec.hopfield, context)
+    return EnergyTransformer(attention=attention, hopfield=hopfield, ...)
+```
+
+## Extending the System
+
+1. Define a Spec dataclass in `spec/library.py`.
+2. Add an auto-import mapping or register a custom realiser with `@register`.

--- a/tests/functional/test_import_behavior.py
+++ b/tests/functional/test_import_behavior.py
@@ -45,20 +45,16 @@ class TestCompleteWorkflows:
 
     def test_custom_model_workflow(self):
         """Test building a custom model with mixed components."""
-        from energy_transformer.spec import loop, parallel
+        from energy_transformer.spec import loop
         from energy_transformer.spec.library import (
+            ETBlockSpec,
             HNSpec,
-            LayerNormSpec,
             MHEASpec,
         )
 
-        custom_block = seq(
-            LayerNormSpec(),
-            parallel(
-                MHEASpec(num_heads=8, head_dim=64),
-                HNSpec(multiplier=2),
-                merge="add",
-            ),
+        custom_block = ETBlockSpec(
+            attention=MHEASpec(num_heads=8, head_dim=64),
+            hopfield=HNSpec(multiplier=2),
         )
 
         model_spec = loop(custom_block, times=3)
@@ -79,7 +75,11 @@ class TestCompleteWorkflows:
         model = realise(deep_spec, embed_dim=768)
 
         num_blocks = len(
-            [m for m in model.modules() if "ETBlock" in str(type(m))],
+            [
+                m
+                for m in model.modules()
+                if m.__class__.__name__ == "EnergyTransformer"
+            ],
         )
         assert num_blocks >= 24
 

--- a/tests/integration/test_spec_model_equivalence.py
+++ b/tests/integration/test_spec_model_equivalence.py
@@ -1,0 +1,352 @@
+"""Integration tests verifying spec system produces identical modules to direct construction."""
+
+import pytest
+import torch
+
+from energy_transformer.layers import (
+    ClassificationHead,
+    CLSToken,
+    HopfieldNetwork,
+    LayerNorm,
+    MultiHeadEnergyAttention,
+    PatchEmbedding,
+    PositionalEmbedding2D,
+)
+from energy_transformer.models import EnergyTransformer
+from energy_transformer.models.vision import (
+    viet_2l_cifar,
+    viet_base,
+    viset_2l_e50_t50_cifar,
+)
+from energy_transformer.spec import Context, loop, realise, seq
+from energy_transformer.spec.library import (
+    ClassificationHeadSpec,
+    CLSTokenSpec,
+    ETBlockSpec,
+    HNSpec,
+    LayerNormSpec,
+    MHEASpec,
+    PatchEmbedSpec,
+    PosEmbedSpec,
+    SHNSpec,
+)
+from energy_transformer.spec.primitives import ValidationError
+
+pytestmark = pytest.mark.integration
+
+
+class TestComponentEquivalence:
+    """Test individual components match between spec and direct construction."""
+
+    def test_patch_embedding_equivalence(self):
+        """PatchEmbedSpec should produce identical PatchEmbedding."""
+        direct = PatchEmbedding(
+            img_size=224,
+            patch_size=16,
+            in_chans=3,
+            embed_dim=768,
+            bias=True,
+        )
+
+        spec = PatchEmbedSpec(
+            img_size=224,
+            patch_size=16,
+            in_chans=3,
+            embed_dim=768,
+            bias=True,
+        )
+        from_spec = realise(spec)
+
+        assert isinstance(from_spec, type(direct))
+        assert direct.img_size == from_spec.img_size
+        assert direct.patch_size == from_spec.patch_size
+        assert direct.num_patches == from_spec.num_patches
+        assert direct.proj.in_channels == from_spec.proj.in_channels
+        assert direct.proj.out_channels == from_spec.proj.out_channels
+        assert direct.proj.kernel_size == from_spec.proj.kernel_size
+        assert direct.proj.stride == from_spec.proj.stride
+
+    def test_cls_token_equivalence(self):
+        """CLSTokenSpec should produce identical CLSToken."""
+        embed_dim = 768
+        direct = CLSToken(embed_dim)
+        spec = CLSTokenSpec()
+        ctx = Context(dimensions={"embed_dim": embed_dim})
+        from_spec = realise(spec, ctx)
+        assert isinstance(from_spec, type(direct))
+        assert direct.cls_token.shape == from_spec.cls_token.shape
+
+    def test_positional_embedding_equivalence(self):
+        """PosEmbedSpec should produce identical PositionalEmbedding2D."""
+        num_patches = 196
+        embed_dim = 768
+        direct = PositionalEmbedding2D(
+            num_patches=num_patches,
+            embed_dim=embed_dim,
+            include_cls=True,
+            init_std=0.02,
+        )
+        spec = PosEmbedSpec(include_cls=True, init_std=0.02)
+        ctx = Context(
+            dimensions={"num_patches": num_patches + 1, "embed_dim": embed_dim}
+        )
+        from_spec = realise(spec, ctx)
+        assert isinstance(from_spec, type(direct))
+        assert direct.pos_embed.shape == from_spec.pos_embed.shape
+        assert direct.init_std == from_spec.init_std
+
+    def test_mhea_equivalence(self):
+        """MHEASpec should produce identical MultiHeadEnergyAttention."""
+        direct = MultiHeadEnergyAttention(
+            in_dim=768,
+            num_heads=12,
+            head_dim=64,
+            beta=None,
+            bias=False,
+            init_std=0.002,
+        )
+        spec = MHEASpec(
+            num_heads=12,
+            head_dim=64,
+            beta=None,
+            bias=False,
+            init_std=0.002,
+        )
+        ctx = Context(dimensions={"embed_dim": 768})
+        from_spec = realise(spec, ctx)
+        assert isinstance(from_spec, type(direct))
+        assert direct.num_heads == from_spec.num_heads
+        assert direct.head_dim == from_spec.head_dim
+        assert direct.in_dim == from_spec.in_dim
+        assert direct.w_k.shape == from_spec.w_k.shape
+        assert direct.w_q.shape == from_spec.w_q.shape
+
+    def test_hopfield_network_equivalence(self):
+        """HNSpec should produce identical HopfieldNetwork."""
+        direct = HopfieldNetwork(in_dim=768, hidden_dim=3072)
+        spec = HNSpec(hidden_dim=3072)
+        ctx = Context(dimensions={"embed_dim": 768})
+        from_spec = realise(spec, ctx)
+        assert isinstance(from_spec, type(direct))
+        assert direct.in_dim == from_spec.in_dim
+        assert direct.hidden_dim == from_spec.hidden_dim
+        assert direct.ξ.shape == from_spec.ξ.shape
+        spec2 = HNSpec(multiplier=4.0)
+        from_spec2 = realise(spec2, ctx)
+        assert from_spec2.hidden_dim == 3072
+
+    def test_layer_norm_equivalence(self):
+        """LayerNormSpec should produce identical LayerNorm."""
+        spec = LayerNormSpec(eps=1e-5)
+        ctx = Context(dimensions={"embed_dim": 768})
+        from_spec = realise(spec, ctx)
+        assert isinstance(from_spec, LayerNorm)
+
+    def test_classification_head_equivalence(self):
+        """ClassificationHeadSpec should produce identical ClassificationHead."""
+        direct = ClassificationHead(
+            embed_dim=768,
+            num_classes=1000,
+            representation_size=None,
+            drop_rate=0.0,
+            use_cls_token=True,
+        )
+        spec = ClassificationHeadSpec(
+            num_classes=1000,
+            representation_size=None,
+            drop_rate=0.0,
+            use_cls_token=True,
+        )
+        ctx = Context(dimensions={"embed_dim": 768})
+        from_spec = realise(spec, ctx)
+        assert isinstance(from_spec, type(direct))
+        assert direct.use_cls_token == from_spec.use_cls_token
+        assert direct.head.in_features == from_spec.head.in_features
+        assert direct.head.out_features == from_spec.head.out_features
+
+
+class TestETBlockEquivalence:
+    """Test Energy Transformer block construction."""
+
+    def test_et_block_construction(self):
+        """ETBlockSpec should produce identical EnergyTransformer."""
+        embed_dim = 768
+        direct = EnergyTransformer(
+            layer_norm=LayerNorm(embed_dim),
+            attention=MultiHeadEnergyAttention(
+                in_dim=embed_dim, num_heads=12, head_dim=64
+            ),
+            hopfield=HopfieldNetwork(in_dim=embed_dim, hidden_dim=3072),
+            steps=4,
+            alpha=0.125,
+        )
+        spec = ETBlockSpec(
+            steps=4,
+            alpha=0.125,
+            layer_norm=LayerNormSpec(),
+            attention=MHEASpec(num_heads=12, head_dim=64),
+            hopfield=HNSpec(hidden_dim=3072),
+        )
+        ctx = Context(dimensions={"embed_dim": embed_dim})
+        from_spec = realise(spec, ctx)
+        assert isinstance(from_spec, type(direct))
+        assert direct.steps == from_spec.steps
+        assert direct.alpha == from_spec.alpha
+        assert isinstance(from_spec.attention, type(direct.attention))
+        assert isinstance(from_spec.hopfield, type(direct.hopfield))
+
+
+class TestFullModelEquivalence:
+    """Test complete model construction matches factory functions."""
+
+    def test_viet_base_construction(self):
+        """Test ViET-Base can be constructed via specs."""
+        img_size = 224
+        patch_size = 16
+        num_classes = 1000
+        embed_dim = 768
+        depth = 12
+        num_heads = 12
+        head_dim = 64
+        hopfield_hidden_dim = 3072
+        et_steps = 4
+        et_alpha = 0.125
+        model_spec = seq(
+            PatchEmbedSpec(
+                img_size=img_size,
+                patch_size=patch_size,
+                in_chans=3,
+                embed_dim=embed_dim,
+            ),
+            CLSTokenSpec(),
+            PosEmbedSpec(include_cls=True),
+            loop(
+                ETBlockSpec(
+                    steps=et_steps,
+                    alpha=et_alpha,
+                    attention=MHEASpec(num_heads=num_heads, head_dim=head_dim),
+                    hopfield=HNSpec(hidden_dim=hopfield_hidden_dim),
+                ),
+                times=depth,
+            ),
+            LayerNormSpec(),
+            ClassificationHeadSpec(num_classes=num_classes, use_cls_token=True),
+        )
+        spec_model = realise(model_spec)
+        direct_model = viet_base(
+            img_size=img_size,
+            patch_size=patch_size,
+            in_chans=3,
+            num_classes=num_classes,
+        )
+        torch.manual_seed(42)
+        x = torch.randn(2, 3, img_size, img_size)
+        spec_out = spec_model(x)
+        direct_out = direct_model(x)
+        assert spec_out.shape == direct_out.shape == (2, num_classes)
+
+    def test_viet_cifar_construction(self):
+        """Test ViET-CIFAR can be constructed via specs."""
+        model_spec = seq(
+            PatchEmbedSpec(
+                img_size=32, patch_size=4, in_chans=3, embed_dim=192
+            ),
+            CLSTokenSpec(),
+            PosEmbedSpec(include_cls=True),
+            loop(
+                ETBlockSpec(
+                    steps=6,
+                    alpha=10.0,
+                    attention=MHEASpec(num_heads=8, head_dim=64),
+                    hopfield=HNSpec(multiplier=3.0),
+                ),
+                times=2,
+            ),
+            LayerNormSpec(),
+            ClassificationHeadSpec(num_classes=100),
+        )
+        spec_model = realise(model_spec)
+        direct_model = viet_2l_cifar(num_classes=100)
+        x = torch.randn(2, 3, 32, 32)
+        assert spec_model(x).shape == direct_model(x).shape
+
+    def test_viset_construction(self):
+        """Test ViSET can be constructed via specs."""
+        model_spec = seq(
+            PatchEmbedSpec(
+                img_size=32, patch_size=4, in_chans=3, embed_dim=192
+            ),
+            CLSTokenSpec(),
+            PosEmbedSpec(include_cls=True),
+            loop(
+                ETBlockSpec(
+                    steps=6,
+                    alpha=10.0,
+                    attention=MHEASpec(num_heads=8, head_dim=64),
+                    hopfield=SHNSpec(
+                        coordinates=[
+                            (i, j) for i in range(8) for j in range(8)
+                        ],
+                        max_dim=2,
+                        budget=0.2,
+                        dim_weights={1: 0.5, 2: 0.5},
+                        num_vertices=64,
+                        multiplier=3.0,
+                    ),
+                ),
+                times=2,
+            ),
+            LayerNormSpec(),
+            ClassificationHeadSpec(num_classes=100),
+        )
+        spec_model = realise(model_spec)
+        direct_model = viset_2l_e50_t50_cifar(num_classes=100)
+        x = torch.randn(2, 3, 32, 32)
+        assert spec_model(x).shape == direct_model(x).shape
+
+
+class TestModelBehavior:
+    """Test that spec-built models exhibit expected behavior."""
+
+    def test_energy_minimization_occurs(self):
+        """Verify ET blocks perform energy minimization."""
+        spec = ETBlockSpec(
+            steps=4,
+            alpha=0.1,
+            attention=MHEASpec(num_heads=4, head_dim=32),
+            hopfield=HNSpec(multiplier=2.0),
+        )
+        ctx = Context(dimensions={"embed_dim": 128})
+        et_block = realise(spec, ctx)
+        x = torch.randn(2, 10, 128, requires_grad=True)
+        result = et_block(x, track="both")
+        if hasattr(result, "trajectory") and result.trajectory is not None:
+            trajectory = result.trajectory
+            assert trajectory.shape[0] == 4
+
+    def test_attention_affects_output(self):
+        """Verify attention mechanism works."""
+        spec = MHEASpec(num_heads=4, head_dim=32)
+        ctx = Context(dimensions={"embed_dim": 128})
+        attn = realise(spec, ctx)
+        x = torch.randn(1, 10, 128)
+        x[:, 0, :] = 10.0
+        with torch.no_grad():
+            energy = attn(x)
+            assert energy.shape == ()
+            assert energy.dtype == torch.float32
+
+
+class TestErrorCases:
+    """Test error handling in spec realisation."""
+
+    def test_missing_dimension_error(self):
+        """Test helpful error when required dimension is missing."""
+        spec = MHEASpec(num_heads=8, head_dim=64)
+        ctx = Context()
+        with pytest.raises(ValidationError) as exc_info:
+            realise(spec, ctx)
+        assert "embed_dim" in str(exc_info.value).lower()
+
+    def test_incompatible_dimensions(self):
+        """Test error when dimensions don't match."""


### PR DESCRIPTION
## Summary
- remove dummy ET specs and implement real EnergyTransformer block
- auto-import MHEA/HN and handle special parameters
- update LayerNorm realisation
- add spec realisation docs
- add integration tests validating spec equivalence
- adjust functional tests for real components

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683c97b269e8832bbe2723d995d57366