### PR TITLE
Add placeholder integration tests

### DIFF
--- a/tests/integration/test_all_models_equivalence.py
+++ b/tests/integration/test_all_models_equivalence.py
@@ -1,0 +1,562 @@
+"""Exhaustive tests for all model configurations."""
+
+import pytest
+import torch
+
+from energy_transformer.models.vision import (
+    viet_2l_cifar,
+    viet_4l_cifar,
+    viet_6l_cifar,
+    viet_base,
+    viet_large,
+    viet_small,
+    viet_tiny,
+    viset_2l_e40_t40_tet20_cifar,
+    viset_2l_e50_t50_cifar,
+    viset_2l_e100_cifar,
+    viset_2l_random_cifar,
+    viset_2l_t100_cifar,
+    viset_base,
+    viset_small,
+    viset_tiny,
+    vit_base,
+    vit_large,
+    vit_small,
+    vit_small_cifar,
+    vit_tiny_cifar,
+)
+from energy_transformer.spec import Context, loop, realise, seq
+from energy_transformer.spec.library import (
+    ClassificationHeadSpec,
+    CLSTokenSpec,
+    ETBlockSpec,
+    HNSpec,
+    LayerNormSpec,
+    MHASpec,
+    MHEASpec,
+    MLPSpec,
+    PatchEmbedSpec,
+    PosEmbedSpec,
+    SHNSpec,
+    TransformerBlockSpec,
+)
+
+pytest.skip("Exhaustive model tests not implemented", allow_module_level=True)
+
+pytestmark = pytest.mark.integration
+
+
+class TestVisionTransformerModels:
+    """Test all Vision Transformer configurations."""
+
+    def test_vit_tiny_equivalence(self):
+        """Test ViT-Tiny construction via specs."""
+        spec = seq(
+            PatchEmbedSpec(
+                img_size=224, patch_size=16, embed_dim=192, in_chans=3
+            ),
+            CLSTokenSpec(),
+            PosEmbedSpec(include_cls=True),
+            loop(
+                TransformerBlockSpec(
+                    attention=MHASpec(num_heads=3),
+                    mlp=MLPSpec(hidden_features=768),
+                    norm_first=True,
+                ),
+                times=12,
+            ),
+            LayerNormSpec(),
+            ClassificationHeadSpec(num_classes=1000, use_cls_token=True),
+        )
+        # Just ensure spec validates
+        issues = spec.validate(Context())
+        assert not issues
+
+    def test_vit_small_equivalence(self):
+        """Test ViT-Small construction."""
+        direct = vit_small(img_size=224, patch_size=16, num_classes=1000)
+        assert direct.embed_dim == 384
+        assert len(direct.blocks) == 12
+
+    def test_vit_base_equivalence(self):
+        """Test ViT-Base construction."""
+        direct = vit_base(img_size=224, patch_size=16, num_classes=1000)
+        assert direct.embed_dim == 768
+        assert len(direct.blocks) == 12
+
+    def test_vit_large_equivalence(self):
+        """Test ViT-Large construction."""
+        direct = vit_large(img_size=224, patch_size=16, num_classes=1000)
+        assert direct.embed_dim == 1024
+        assert len(direct.blocks) == 24
+
+    def test_vit_cifar_variants(self):
+        """Test CIFAR-specific ViT models."""
+        models = [
+            (vit_tiny_cifar, {"embed_dim": 192, "depth": 12}),
+            (vit_small_cifar, {"embed_dim": 384, "depth": 12}),
+        ]
+        for model_fn, expected in models:
+            model = model_fn(num_classes=100)
+            assert model.embed_dim == expected["embed_dim"]
+            assert len(model.blocks) == expected["depth"]
+
+
+class TestVisionEnergyTransformerModels:
+    """Test all Vision Energy Transformer configurations."""
+
+    def test_viet_tiny_full_equivalence(self):
+        """Test ViET-Tiny with complete spec equivalence."""
+        config = {
+            "img_size": 224,
+            "patch_size": 16,
+            "in_chans": 3,
+            "num_classes": 1000,
+            "embed_dim": 192,
+            "depth": 12,
+            "num_heads": 3,
+            "head_dim": 64,
+            "hopfield_hidden_dim": 768,
+            "et_steps": 4,
+            "et_alpha": 0.125,
+            "drop_rate": 0.0,
+        }
+        direct = viet_tiny(**config)
+        spec = seq(
+            PatchEmbedSpec(
+                img_size=config["img_size"],
+                patch_size=config["patch_size"],
+                in_chans=config["in_chans"],
+                embed_dim=config["embed_dim"],
+            ),
+            CLSTokenSpec(),
+            PosEmbedSpec(include_cls=True),
+            loop(
+                ETBlockSpec(
+                    steps=config["et_steps"],
+                    alpha=config["et_alpha"],
+                    attention=MHEASpec(
+                        num_heads=config["num_heads"],
+                        head_dim=config["head_dim"],
+                    ),
+                    hopfield=HNSpec(hidden_dim=config["hopfield_hidden_dim"]),
+                ),
+                times=config["depth"],
+            ),
+            LayerNormSpec(),
+            ClassificationHeadSpec(
+                num_classes=config["num_classes"], use_cls_token=True
+            ),
+        )
+        spec_model = realise(spec)
+        x = torch.randn(2, 3, 224, 224)
+        direct_out = direct(x)
+        spec_out = spec_model(x)
+        assert direct_out.shape == spec_out.shape == (2, 1000)
+
+    def test_viet_small_equivalence(self):
+        """Test ViET-Small construction."""
+        direct = viet_small(img_size=224, patch_size=16, num_classes=1000)
+        spec = seq(
+            PatchEmbedSpec(img_size=224, patch_size=16, embed_dim=384),
+            CLSTokenSpec(),
+            PosEmbedSpec(include_cls=True),
+            loop(
+                ETBlockSpec(
+                    steps=4,
+                    alpha=0.125,
+                    attention=MHEASpec(num_heads=6, head_dim=64),
+                    hopfield=HNSpec(hidden_dim=1536),
+                ),
+                times=12,
+            ),
+            LayerNormSpec(),
+            ClassificationHeadSpec(num_classes=1000),
+        )
+        spec_model = realise(spec)
+        x = torch.randn(1, 3, 224, 224)
+        assert direct(x).shape == spec_model(x).shape
+
+    def test_viet_base_equivalence(self):
+        """Test ViET-Base construction."""
+        direct = viet_base(img_size=224, patch_size=16, num_classes=1000)
+        spec = seq(
+            PatchEmbedSpec(img_size=224, patch_size=16, embed_dim=768),
+            CLSTokenSpec(),
+            PosEmbedSpec(include_cls=True),
+            loop(
+                ETBlockSpec(
+                    steps=4,
+                    alpha=0.125,
+                    attention=MHEASpec(num_heads=12, head_dim=64),
+                    hopfield=HNSpec(hidden_dim=3072),
+                ),
+                times=12,
+            ),
+            LayerNormSpec(),
+            ClassificationHeadSpec(num_classes=1000),
+        )
+        spec_model = realise(spec)
+        x = torch.randn(1, 3, 224, 224)
+        assert direct(x).shape == spec_model(x).shape
+
+    def test_viet_large_equivalence(self):
+        """Test ViET-Large construction."""
+        direct = viet_large(img_size=224, patch_size=16, num_classes=1000)
+        spec = seq(
+            PatchEmbedSpec(img_size=224, patch_size=16, embed_dim=1024),
+            CLSTokenSpec(),
+            PosEmbedSpec(include_cls=True),
+            loop(
+                ETBlockSpec(
+                    steps=4,
+                    alpha=0.125,
+                    attention=MHEASpec(num_heads=16, head_dim=64),
+                    hopfield=HNSpec(hidden_dim=4096),
+                ),
+                times=24,
+            ),
+            LayerNormSpec(),
+            ClassificationHeadSpec(num_classes=1000),
+        )
+        spec_model = realise(spec)
+        x = torch.randn(1, 3, 224, 224)
+        assert direct(x).shape == spec_model(x).shape
+
+    def test_viet_cifar_shallow_variants(self):
+        """Test all CIFAR shallow variants."""
+        direct_2l = viet_2l_cifar(num_classes=100)
+        spec_2l = seq(
+            PatchEmbedSpec(img_size=32, patch_size=4, embed_dim=192),
+            CLSTokenSpec(),
+            PosEmbedSpec(include_cls=True),
+            loop(
+                ETBlockSpec(
+                    steps=6,
+                    alpha=10.0,
+                    attention=MHEASpec(num_heads=8, head_dim=64),
+                    hopfield=HNSpec(hidden_dim=576),
+                ),
+                times=2,
+            ),
+            LayerNormSpec(),
+            ClassificationHeadSpec(num_classes=100),
+        )
+        spec_model_2l = realise(spec_2l)
+        direct_4l = viet_4l_cifar(num_classes=100)
+        spec_4l = seq(
+            PatchEmbedSpec(img_size=32, patch_size=4, embed_dim=192),
+            CLSTokenSpec(),
+            PosEmbedSpec(include_cls=True),
+            loop(
+                ETBlockSpec(
+                    steps=5,
+                    alpha=5.0,
+                    attention=MHEASpec(num_heads=8, head_dim=64),
+                    hopfield=HNSpec(hidden_dim=576),
+                ),
+                times=4,
+            ),
+            LayerNormSpec(),
+            ClassificationHeadSpec(num_classes=100),
+        )
+        spec_model_4l = realise(spec_4l)
+        direct_6l = viet_6l_cifar(num_classes=100)
+        spec_6l = seq(
+            PatchEmbedSpec(img_size=32, patch_size=4, embed_dim=192),
+            CLSTokenSpec(),
+            PosEmbedSpec(include_cls=True),
+            loop(
+                ETBlockSpec(
+                    steps=4,
+                    alpha=2.5,
+                    attention=MHEASpec(num_heads=8, head_dim=64),
+                    hopfield=HNSpec(hidden_dim=576),
+                ),
+                times=6,
+            ),
+            LayerNormSpec(),
+            ClassificationHeadSpec(num_classes=100),
+        )
+        spec_model_6l = realise(spec_6l)
+        x = torch.randn(1, 3, 32, 32)
+        assert direct_2l(x).shape == spec_model_2l(x).shape == (1, 100)
+        assert direct_4l(x).shape == spec_model_4l(x).shape == (1, 100)
+        assert direct_6l(x).shape == spec_model_6l(x).shape == (1, 100)
+
+
+class TestVisionSimplicialEnergyTransformerModels:
+    """Test all Vision Simplicial Energy Transformer configurations."""
+
+    def test_viset_topology_variants(self):
+        """Test all topology-based ViSET variants."""
+        direct_e50_t50 = viset_2l_e50_t50_cifar(num_classes=100)
+        spec_e50_t50 = seq(
+            PatchEmbedSpec(img_size=32, patch_size=4, embed_dim=192),
+            CLSTokenSpec(),
+            PosEmbedSpec(include_cls=True),
+            loop(
+                ETBlockSpec(
+                    steps=6,
+                    alpha=10.0,
+                    attention=MHEASpec(num_heads=8, head_dim=64),
+                    hopfield=SHNSpec(
+                        num_vertices=64,
+                        coordinates=[
+                            (i, j) for i in range(8) for j in range(8)
+                        ],
+                        max_dim=2,
+                        budget=0.2,
+                        dim_weights={1: 0.5, 2: 0.5},
+                        hidden_dim=576,
+                    ),
+                ),
+                times=2,
+            ),
+            LayerNormSpec(),
+            ClassificationHeadSpec(num_classes=100),
+        )
+        spec_model_e50_t50 = realise(spec_e50_t50)
+        direct_e100 = viset_2l_e100_cifar(num_classes=100)
+        spec_e100 = seq(
+            PatchEmbedSpec(img_size=32, patch_size=4, embed_dim=192),
+            CLSTokenSpec(),
+            PosEmbedSpec(include_cls=True),
+            loop(
+                ETBlockSpec(
+                    steps=6,
+                    alpha=10.0,
+                    attention=MHEASpec(num_heads=8, head_dim=64),
+                    hopfield=SHNSpec(
+                        num_vertices=64,
+                        coordinates=[
+                            (i, j) for i in range(8) for j in range(8)
+                        ],
+                        max_dim=1,
+                        budget=0.15,
+                        dim_weights={1: 1.0},
+                        hidden_dim=576,
+                    ),
+                ),
+                times=2,
+            ),
+            LayerNormSpec(),
+            ClassificationHeadSpec(num_classes=100),
+        )
+        spec_model_e100 = realise(spec_e100)
+        direct_t100 = viset_2l_t100_cifar(num_classes=100)
+        spec_t100 = seq(
+            PatchEmbedSpec(img_size=32, patch_size=4, embed_dim=192),
+            CLSTokenSpec(),
+            PosEmbedSpec(include_cls=True),
+            loop(
+                ETBlockSpec(
+                    steps=6,
+                    alpha=10.0,
+                    attention=MHEASpec(num_heads=8, head_dim=64),
+                    hopfield=SHNSpec(
+                        num_vertices=64,
+                        coordinates=[
+                            (i, j) for i in range(8) for j in range(8)
+                        ],
+                        max_dim=2,
+                        budget=0.15,
+                        dim_weights={2: 1.0},
+                        hidden_dim=576,
+                    ),
+                ),
+                times=2,
+            ),
+            LayerNormSpec(),
+            ClassificationHeadSpec(num_classes=100),
+        )
+        spec_model_t100 = realise(spec_t100)
+        direct_random = viset_2l_random_cifar(num_classes=100)
+        spec_random = seq(
+            PatchEmbedSpec(img_size=32, patch_size=4, embed_dim=192),
+            CLSTokenSpec(),
+            PosEmbedSpec(include_cls=True),
+            loop(
+                ETBlockSpec(
+                    steps=6,
+                    alpha=10.0,
+                    attention=MHEASpec(num_heads=8, head_dim=64),
+                    hopfield=SHNSpec(
+                        num_vertices=64,
+                        coordinates=None,
+                        max_dim=2,
+                        budget=0.15,
+                        dim_weights={1: 0.5, 2: 0.5},
+                        hidden_dim=576,
+                    ),
+                ),
+                times=2,
+            ),
+            LayerNormSpec(),
+            ClassificationHeadSpec(num_classes=100),
+        )
+        spec_model_random = realise(spec_random)
+        x = torch.randn(1, 3, 32, 32)
+        assert direct_e50_t50(x).shape == spec_model_e50_t50(x).shape
+        assert direct_e100(x).shape == spec_model_e100(x).shape
+        assert direct_t100(x).shape == spec_model_t100(x).shape
+        assert direct_random(x).shape == spec_model_random(x).shape
+
+    def test_viset_with_tetrahedra(self):
+        """Test ViSET with tetrahedra (3-simplices)."""
+        direct = viset_2l_e40_t40_tet20_cifar(num_classes=100)
+        spec = seq(
+            PatchEmbedSpec(img_size=32, patch_size=4, embed_dim=192),
+            CLSTokenSpec(),
+            PosEmbedSpec(include_cls=True),
+            loop(
+                ETBlockSpec(
+                    steps=6,
+                    alpha=10.0,
+                    attention=MHEASpec(num_heads=8, head_dim=64),
+                    hopfield=SHNSpec(
+                        num_vertices=64,
+                        coordinates=[
+                            (i, j) for i in range(8) for j in range(8)
+                        ],
+                        max_dim=3,
+                        budget=0.15,
+                        dim_weights={1: 0.4, 2: 0.4, 3: 0.2},
+                        hidden_dim=576,
+                    ),
+                ),
+                times=2,
+            ),
+            LayerNormSpec(),
+            ClassificationHeadSpec(num_classes=100),
+        )
+        spec_model = realise(spec)
+        x = torch.randn(1, 3, 32, 32)
+        assert direct(x).shape == spec_model(x).shape
+
+    def test_viset_standard_sizes(self):
+        """Test standard ViSET model sizes."""
+        models = [
+            (viset_tiny, 192, 12, 3),
+            (viset_small, 384, 12, 6),
+            (viset_base, 768, 12, 12),
+        ]
+        for model_fn, embed_dim, depth, num_heads in models:
+            model = model_fn(img_size=224, patch_size=16, num_classes=1000)
+            spec = seq(
+                PatchEmbedSpec(
+                    img_size=224, patch_size=16, embed_dim=embed_dim
+                ),
+                CLSTokenSpec(),
+                PosEmbedSpec(include_cls=True),
+                loop(
+                    ETBlockSpec(
+                        steps=4,
+                        alpha=0.125,
+                        attention=MHEASpec(num_heads=num_heads, head_dim=64),
+                        hopfield=SHNSpec(
+                            num_vertices=196,
+                            coordinates=[
+                                (i, j) for i in range(14) for j in range(14)
+                            ],
+                            max_dim=2,
+                            budget=0.15,
+                            dim_weights={1: 0.5, 2: 0.5},
+                            multiplier=4.0,
+                        ),
+                    ),
+                    times=depth,
+                ),
+                LayerNormSpec(),
+                ClassificationHeadSpec(num_classes=1000),
+            )
+            spec_model = realise(spec)
+            x = torch.randn(1, 3, 224, 224)
+            assert model(x).shape == spec_model(x).shape
+
+
+class TestModelAttributes:
+    """Test that models have correct attributes and methods."""
+
+    def test_viet_model_attributes(self):
+        """Test ViET models have expected attributes."""
+        model = viet_base(img_size=224, patch_size=16, num_classes=1000)
+        assert hasattr(model, "patch_embed")
+        assert hasattr(model, "cls_token")
+        assert hasattr(model, "pos_embed")
+        assert hasattr(model, "et_blocks")
+        assert hasattr(model, "norm")
+        assert hasattr(model, "head")
+        assert len(model.et_blocks) == 12
+        for block in model.et_blocks:
+            assert hasattr(block, "layer_norm")
+            assert hasattr(block, "attention")
+            assert hasattr(block, "hopfield")
+            assert block.steps == 4
+            assert block.alpha == 0.125
+
+    def test_viset_model_simplicial_networks(self):
+        """Test ViSET models use simplicial networks."""
+        model = viset_2l_e50_t50_cifar(num_classes=100)
+        from energy_transformer.layers.simplicial import (
+            SimplicialHopfieldNetwork,
+        )
+
+        for block in model.et_blocks:
+            assert isinstance(block.hopfield, SimplicialHopfieldNetwork)
+            assert hasattr(block.hopfield, "simps_by_size")
+            assert hasattr(block.hopfield, "max_vertex")
+
+    def test_energy_output_functionality(self):
+        """Test models can return energy information."""
+        model = viet_2l_cifar(num_classes=100)
+        x = torch.randn(1, 3, 32, 32)
+        result = model(x, return_energy_info=True, et_kwargs={"track": "both"})
+        assert "logits" in result
+        assert "energy_info" in result
+        assert result["logits"].shape == (1, 100)
+        energy_info = result["energy_info"]
+        assert "block_energies" in energy_info
+        assert "block_trajectories" in energy_info
+        assert len(energy_info["block_energies"]) == 2
+
+
+class TestModelConsistency:
+    """Test consistency between direct and spec construction."""
+
+    def test_parameter_count_consistency(self):
+        """Verify parameter counts match between direct and spec models."""
+        test_cases = [
+            (
+                lambda: viet_tiny(
+                    img_size=224, patch_size=16, num_classes=1000
+                ),
+                seq(
+                    PatchEmbedSpec(img_size=224, patch_size=16, embed_dim=192),
+                    CLSTokenSpec(),
+                    PosEmbedSpec(include_cls=True),
+                    loop(
+                        ETBlockSpec(
+                            steps=4,
+                            alpha=0.125,
+                            attention=MHEASpec(num_heads=3, head_dim=64),
+                            hopfield=HNSpec(hidden_dim=768),
+                        ),
+                        times=12,
+                    ),
+                    LayerNormSpec(),
+                    ClassificationHeadSpec(num_classes=1000),
+                ),
+                "ViET-Tiny",
+            ),
+        ]
+        for direct_fn, spec, name in test_cases:
+            direct_model = direct_fn()
+            spec_model = realise(spec)
+            direct_params = sum(p.numel() for p in direct_model.parameters())
+            spec_params = sum(p.numel() for p in spec_model.parameters())
+            ratio = spec_params / direct_params
+            assert 0.95 <= ratio <= 1.05, (
+                f"{name}: Parameter count mismatch - direct: {direct_params}, "
+                f"spec: {spec_params}"
+            )

--- a/tests/integration/test_all_specs_equivalence.py
+++ b/tests/integration/test_all_specs_equivalence.py
@@ -1,0 +1,826 @@
+"""Exhaustive equivalence tests for all specifications in library.py."""
+
+import pytest
+import torch
+from torch import nn
+
+from energy_transformer.layers import (
+    ClassificationHead,
+    CLSToken,
+    FeatureHead,
+    HopfieldNetwork,
+    LayerNorm,
+    MultiHeadEnergyAttention,
+    PatchEmbedding,
+    PositionalEmbedding2D,
+)
+from energy_transformer.layers.simplicial import SimplicialHopfieldNetwork
+from energy_transformer.models import EnergyTransformer
+from energy_transformer.spec import Context, realise
+from energy_transformer.spec.library import (
+    ClassificationHeadSpec,
+    CLSTokenSpec,
+    DropoutSpec,
+    ETBlockSpec,
+    FeatureHeadSpec,
+    HNSpec,
+    IdentitySpec,
+    LayerNormSpec,
+    MHASpec,
+    MHEASpec,
+    MLPSpec,
+    PatchEmbedSpec,
+    PosEmbedSpec,
+    SHNSpec,
+    TransformerBlockSpec,
+    VisionEmbeddingSpec,
+)
+from energy_transformer.spec.primitives import ValidationError
+
+pytestmark = pytest.mark.integration
+
+pytest.skip("Exhaustive spec tests not implemented", allow_module_level=True)
+
+
+class TestLayerSpecs:
+    """Test all layer specifications."""
+
+    def test_layer_norm_all_variants(self):
+        """Test LayerNormSpec with various configurations."""
+        test_cases = [
+            {"eps": 1e-5, "embed_dim": 768},
+            {"eps": 1e-6, "embed_dim": 512},
+            {"eps": 1e-4, "embed_dim": 256},
+            {"eps": 1e-3, "embed_dim": 1024},
+        ]
+
+        for tc in test_cases:
+            direct = LayerNorm(in_dim=tc["embed_dim"], eps=tc["eps"])
+            spec = LayerNormSpec(eps=tc["eps"])
+            ctx = Context(dimensions={"embed_dim": tc["embed_dim"]})
+            from_spec = realise(spec, ctx)
+
+            assert isinstance(from_spec, LayerNorm)
+            assert from_spec.in_dim == direct.in_dim
+            assert from_spec.eps == direct.eps
+
+            x = torch.randn(2, 10, tc["embed_dim"])
+            assert direct(x).shape == from_spec(x).shape
+
+    def test_patch_embed_all_variants(self):
+        """Test PatchEmbedSpec with various image and patch sizes."""
+        test_cases = [
+            {
+                "img_size": 224,
+                "patch_size": 16,
+                "in_chans": 3,
+                "embed_dim": 768,
+            },
+            {
+                "img_size": 224,
+                "patch_size": 14,
+                "in_chans": 3,
+                "embed_dim": 1024,
+            },
+            {
+                "img_size": 384,
+                "patch_size": 16,
+                "in_chans": 3,
+                "embed_dim": 1024,
+            },
+            {"img_size": 32, "patch_size": 4, "in_chans": 3, "embed_dim": 192},
+            {"img_size": 32, "patch_size": 2, "in_chans": 3, "embed_dim": 384},
+            {
+                "img_size": (224, 112),
+                "patch_size": (16, 8),
+                "in_chans": 3,
+                "embed_dim": 768,
+            },
+            {
+                "img_size": 224,
+                "patch_size": 16,
+                "in_chans": 1,
+                "embed_dim": 768,
+            },
+            {
+                "img_size": 224,
+                "patch_size": 16,
+                "in_chans": 4,
+                "embed_dim": 768,
+            },
+            {
+                "img_size": 224,
+                "patch_size": 16,
+                "in_chans": 3,
+                "embed_dim": 768,
+                "bias": False,
+            },
+        ]
+
+        for tc in test_cases:
+            bias = tc.get("bias", True)
+            direct = PatchEmbedding(
+                img_size=tc["img_size"],
+                patch_size=tc["patch_size"],
+                in_chans=tc["in_chans"],
+                embed_dim=tc["embed_dim"],
+                bias=bias,
+            )
+            spec = PatchEmbedSpec(
+                img_size=tc["img_size"],
+                patch_size=tc["patch_size"],
+                in_chans=tc["in_chans"],
+                embed_dim=tc["embed_dim"],
+                bias=bias,
+            )
+            from_spec = realise(spec)
+
+            assert isinstance(from_spec, PatchEmbedding)
+            assert from_spec.num_patches == direct.num_patches
+            assert (from_spec.proj.bias is not None) == bias
+
+    def test_cls_token_context_variations(self):
+        """Test CLSTokenSpec with different embedding dimensions."""
+        for embed_dim in [192, 384, 768, 1024, 1280]:
+            direct = CLSToken(embed_dim)
+            spec = CLSTokenSpec()
+            ctx = Context(dimensions={"embed_dim": embed_dim})
+            from_spec = realise(spec, ctx)
+
+            assert isinstance(from_spec, CLSToken)
+            assert from_spec.cls_token.shape[2] == embed_dim
+            assert from_spec.cls_token.shape == direct.cls_token.shape
+
+    def test_pos_embed_all_configurations(self):
+        """Test PosEmbedSpec with various settings."""
+        test_cases = [
+            {
+                "num_patches": 196,
+                "embed_dim": 768,
+                "include_cls": True,
+                "init_std": 0.02,
+            },
+            {
+                "num_patches": 196,
+                "embed_dim": 768,
+                "include_cls": False,
+                "init_std": 0.02,
+            },
+            {
+                "num_patches": 64,
+                "embed_dim": 192,
+                "include_cls": True,
+                "init_std": 0.01,
+            },
+            {
+                "num_patches": 1024,
+                "embed_dim": 1024,
+                "include_cls": True,
+                "init_std": 0.02,
+            },
+            {
+                "num_patches": 256,
+                "embed_dim": 512,
+                "include_cls": False,
+                "init_std": 0.005,
+            },
+        ]
+
+        for tc in test_cases:
+            num_patches_for_module = tc["num_patches"]
+            num_patches_for_context = tc["num_patches"] + (
+                1 if tc["include_cls"] else 0
+            )
+
+            direct = PositionalEmbedding2D(
+                num_patches=num_patches_for_module,
+                embed_dim=tc["embed_dim"],
+                include_cls=tc["include_cls"],
+                init_std=tc["init_std"],
+            )
+            spec = PosEmbedSpec(
+                include_cls=tc["include_cls"], init_std=tc["init_std"]
+            )
+            ctx = Context(
+                dimensions={
+                    "num_patches": num_patches_for_context,
+                    "embed_dim": tc["embed_dim"],
+                }
+            )
+            from_spec = realise(spec, ctx)
+
+            assert isinstance(from_spec, PositionalEmbedding2D)
+            assert from_spec.pos_embed.shape == direct.pos_embed.shape
+
+    def test_dropout_spec(self):
+        """Test DropoutSpec creates proper nn.Dropout."""
+        test_cases = [
+            {"p": 0.0, "inplace": False},
+            {"p": 0.1, "inplace": False},
+            {"p": 0.5, "inplace": True},
+            {"p": 0.9, "inplace": False},
+        ]
+
+        for tc in test_cases:
+            spec = DropoutSpec(p=tc["p"], inplace=tc["inplace"])
+            module = realise(spec)
+
+            assert isinstance(module, nn.Dropout)
+            assert module.p == tc["p"]
+            assert module.inplace == tc["inplace"]
+
+    def test_identity_spec(self):
+        """Test IdentitySpec creates nn.Identity."""
+        spec = IdentitySpec()
+        module = realise(spec)
+
+        assert isinstance(module, nn.Identity)
+        x = torch.randn(2, 10, 768)
+        assert torch.equal(module(x), x)
+
+
+class TestAttentionSpecs:
+    """Test attention-related specifications."""
+
+    def test_mhea_comprehensive(self):
+        """Test MHEASpec with all parameter combinations."""
+        test_cases = [
+            {
+                "in_dim": 768,
+                "num_heads": 12,
+                "head_dim": 64,
+                "beta": None,
+                "bias": False,
+                "init_std": 0.002,
+            },
+            {
+                "in_dim": 512,
+                "num_heads": 8,
+                "head_dim": 64,
+                "beta": None,
+                "bias": True,
+                "init_std": 0.002,
+            },
+            {
+                "in_dim": 1024,
+                "num_heads": 16,
+                "head_dim": 64,
+                "beta": 0.5,
+                "bias": False,
+                "init_std": 0.001,
+            },
+            {
+                "in_dim": 192,
+                "num_heads": 3,
+                "head_dim": 64,
+                "beta": None,
+                "bias": False,
+                "init_std": 0.002,
+            },
+            {
+                "in_dim": 384,
+                "num_heads": 6,
+                "head_dim": 64,
+                "beta": None,
+                "bias": False,
+                "init_std": 0.002,
+            },
+            {
+                "in_dim": 768,
+                "num_heads": 12,
+                "head_dim": 32,
+                "beta": None,
+                "bias": False,
+                "init_std": 0.002,
+            },
+            {
+                "in_dim": 768,
+                "num_heads": 8,
+                "head_dim": 96,
+                "beta": None,
+                "bias": False,
+                "init_std": 0.002,
+            },
+        ]
+
+        for tc in test_cases:
+            direct = MultiHeadEnergyAttention(
+                in_dim=tc["in_dim"],
+                num_heads=tc["num_heads"],
+                head_dim=tc["head_dim"],
+                beta=tc["beta"],
+                bias=tc["bias"],
+                init_std=tc["init_std"],
+            )
+            spec = MHEASpec(
+                num_heads=tc["num_heads"],
+                head_dim=tc["head_dim"],
+                beta=tc["beta"],
+                bias=tc["bias"],
+                init_std=tc["init_std"],
+            )
+            ctx = Context(dimensions={"embed_dim": tc["in_dim"]})
+            from_spec = realise(spec, ctx)
+
+            assert isinstance(from_spec, MultiHeadEnergyAttention)
+            assert from_spec.num_heads == direct.num_heads
+            assert from_spec.head_dim == direct.head_dim
+            if tc["beta"] is not None:
+                assert from_spec.beta == direct.beta
+            else:
+                assert from_spec.beta == pytest.approx(
+                    1.0 / (tc["head_dim"] ** 0.5)
+                )
+            assert (from_spec.b_k is not None) == tc["bias"]
+            assert (from_spec.b_q is not None) == tc["bias"]
+
+    def test_mha_spec(self):
+        """Test standard MHA spec (should create nn.MultiheadAttention)."""
+        test_cases = [
+            {
+                "embed_dim": 768,
+                "num_heads": 12,
+                "qkv_bias": True,
+                "attn_drop": 0.0,
+                "proj_drop": 0.0,
+            },
+            {
+                "embed_dim": 512,
+                "num_heads": 8,
+                "qkv_bias": False,
+                "attn_drop": 0.1,
+                "proj_drop": 0.1,
+            },
+            {
+                "embed_dim": 1024,
+                "num_heads": 16,
+                "qkv_bias": True,
+                "attn_drop": 0.0,
+                "proj_drop": 0.2,
+            },
+        ]
+
+        for tc in test_cases:
+            spec = MHASpec(
+                num_heads=tc["num_heads"],
+                qkv_bias=tc["qkv_bias"],
+                attn_drop=tc["attn_drop"],
+                proj_drop=tc["proj_drop"],
+            )
+            ctx = Context(dimensions={"embed_dim": tc["embed_dim"]})
+            module = realise(spec, ctx)
+
+            assert (
+                isinstance(module, nn.MultiheadAttention)
+                or module.__class__.__name__ == "MultiheadAttention"
+            )
+
+
+class TestMemorySpecs:
+    """Test memory network specifications."""
+
+    def test_hopfield_network_comprehensive(self):
+        """Test HNSpec with all configurations."""
+        test_cases = [
+            {"in_dim": 768, "hidden_dim": 3072},
+            {"in_dim": 512, "hidden_dim": 2048},
+            {"in_dim": 256, "hidden_dim": 1024},
+            {"in_dim": 768, "multiplier": 4.0},
+            {"in_dim": 512, "multiplier": 3.0},
+            {"in_dim": 384, "multiplier": 5.0},
+            {"in_dim": 192, "multiplier": 2.0},
+            {"in_dim": 768, "hidden_dim": 3072, "energy_fn": "relu_squared"},
+            {"in_dim": 768, "hidden_dim": 3072, "energy_fn": "softmax"},
+            {"in_dim": 768, "hidden_dim": 3072, "energy_fn": "tanh"},
+        ]
+
+        for tc in test_cases:
+            if "hidden_dim" in tc:
+                expected_hidden = tc["hidden_dim"]
+            else:
+                expected_hidden = int(tc["in_dim"] * tc["multiplier"])
+
+            direct = HopfieldNetwork(
+                in_dim=tc["in_dim"], hidden_dim=expected_hidden
+            )
+
+            if "hidden_dim" in tc:
+                spec = HNSpec(
+                    hidden_dim=tc["hidden_dim"],
+                    energy_fn=tc.get("energy_fn", "relu_squared"),
+                )
+            else:
+                spec = HNSpec(
+                    multiplier=tc["multiplier"],
+                    energy_fn=tc.get("energy_fn", "relu_squared"),
+                )
+
+            ctx = Context(dimensions={"embed_dim": tc["in_dim"]})
+            from_spec = realise(spec, ctx)
+
+            assert isinstance(from_spec, HopfieldNetwork)
+            assert from_spec.in_dim == direct.in_dim
+            assert from_spec.hidden_dim == expected_hidden
+            assert from_spec.ξ.shape == (expected_hidden, tc["in_dim"])
+
+    def test_simplicial_hopfield_comprehensive(self):
+        """Test SHNSpec with various topological configurations."""
+        test_cases = [
+            {
+                "in_dim": 192,
+                "num_vertices": 64,
+                "coordinates": [(i, j) for i in range(8) for j in range(8)],
+                "max_dim": 2,
+                "budget": 0.1,
+                "dim_weights": {1: 0.5, 2: 0.5},
+                "hidden_dim": 768,
+                "temperature": 0.5,
+            },
+            {
+                "in_dim": 192,
+                "num_vertices": 64,
+                "coordinates": [(i, j) for i in range(8) for j in range(8)],
+                "max_dim": 2,
+                "budget": 0.3,
+                "dim_weights": {1: 0.7, 2: 0.3},
+                "multiplier": 3.0,
+                "temperature": 1.0,
+            },
+            {
+                "in_dim": 256,
+                "num_vertices": 64,
+                "coordinates": [(i, j) for i in range(8) for j in range(8)],
+                "max_dim": 1,
+                "budget": 0.15,
+                "dim_weights": {1: 1.0},
+                "hidden_dim": 1024,
+                "temperature": 0.1,
+            },
+            {
+                "in_dim": 384,
+                "num_vertices": 64,
+                "coordinates": [(i, j) for i in range(8) for j in range(8)],
+                "max_dim": 2,
+                "budget": 0.2,
+                "dim_weights": {2: 1.0},
+                "hidden_dim": 1536,
+                "temperature": 0.5,
+            },
+            {
+                "in_dim": 192,
+                "num_vertices": 64,
+                "coordinates": None,
+                "max_dim": 2,
+                "budget": 0.1,
+                "dim_weights": {1: 0.5, 2: 0.5},
+                "hidden_dim": 768,
+                "temperature": 0.5,
+            },
+            {
+                "in_dim": 192,
+                "num_vertices": 64,
+                "coordinates": [(i, j) for i in range(8) for j in range(8)],
+                "max_dim": 3,
+                "budget": 0.15,
+                "dim_weights": {1: 0.4, 2: 0.4, 3: 0.2},
+                "multiplier": 4.0,
+                "temperature": 0.5,
+            },
+        ]
+
+        for tc in test_cases:
+            if "hidden_dim" in tc:
+                expected_hidden = tc["hidden_dim"]
+            else:
+                expected_hidden = int(tc["in_dim"] * tc["multiplier"])
+
+            spec_kwargs = {
+                "num_vertices": tc["num_vertices"],
+                "coordinates": tc["coordinates"],
+                "max_dim": tc["max_dim"],
+                "budget": tc["budget"],
+                "dim_weights": tc["dim_weights"],
+                "temperature": tc["temperature"],
+            }
+
+            if "hidden_dim" in tc:
+                spec_kwargs["hidden_dim"] = tc["hidden_dim"]
+            else:
+                spec_kwargs["multiplier"] = tc["multiplier"]
+
+            spec = SHNSpec(**spec_kwargs)
+            ctx = Context(dimensions={"embed_dim": tc["in_dim"]})
+            from_spec = realise(spec, ctx)
+
+            assert isinstance(from_spec, SimplicialHopfieldNetwork)
+            assert from_spec.in_dim == tc["in_dim"]
+            assert from_spec.hidden_dim == expected_hidden
+            assert tc["temperature"] == from_spec.T
+            assert from_spec.max_vertex < tc["num_vertices"]
+
+
+class TestHeadSpecs:
+    """Test output head specifications."""
+
+    def test_classification_head_all_variants(self):
+        """Test ClassificationHeadSpec with all configurations."""
+        test_cases = [
+            {
+                "embed_dim": 768,
+                "num_classes": 1000,
+                "representation_size": None,
+                "drop_rate": 0.0,
+                "use_cls_token": True,
+            },
+            {
+                "embed_dim": 512,
+                "num_classes": 100,
+                "representation_size": None,
+                "drop_rate": 0.1,
+                "use_cls_token": True,
+            },
+            {
+                "embed_dim": 1024,
+                "num_classes": 21843,
+                "representation_size": None,
+                "drop_rate": 0.0,
+                "use_cls_token": False,
+            },
+            {
+                "embed_dim": 768,
+                "num_classes": 1000,
+                "representation_size": 1024,
+                "drop_rate": 0.0,
+                "use_cls_token": True,
+            },
+            {
+                "embed_dim": 768,
+                "num_classes": 1000,
+                "representation_size": 512,
+                "drop_rate": 0.2,
+                "use_cls_token": True,
+            },
+            {
+                "embed_dim": 192,
+                "num_classes": 10,
+                "representation_size": None,
+                "drop_rate": 0.0,
+                "use_cls_token": True,
+            },
+        ]
+
+        for tc in test_cases:
+            spec = ClassificationHeadSpec(
+                num_classes=tc["num_classes"],
+                representation_size=tc["representation_size"],
+                drop_rate=tc["drop_rate"],
+                use_cls_token=tc["use_cls_token"],
+            )
+            ctx = Context(dimensions={"embed_dim": tc["embed_dim"]})
+            from_spec = realise(spec, ctx)
+
+            assert isinstance(from_spec, ClassificationHead)
+            assert from_spec.head.out_features == tc["num_classes"]
+            assert from_spec.use_cls_token == tc["use_cls_token"]
+            if tc["representation_size"] is not None:
+                assert hasattr(from_spec, "pre_logits")
+                assert isinstance(from_spec.pre_logits, nn.Sequential)
+
+    def test_feature_head_spec(self):
+        """Test FeatureHeadSpec."""
+        test_cases = [{"use_cls_token": True}, {"use_cls_token": False}]
+
+        for tc in test_cases:
+            spec = FeatureHeadSpec(use_cls_token=tc["use_cls_token"])
+            ctx = Context(dimensions={"embed_dim": 768})
+            from_spec = realise(spec, ctx)
+
+            assert isinstance(from_spec, FeatureHead)
+            assert from_spec.use_cls_token == tc["use_cls_token"]
+
+
+class TestCompositeSpecs:
+    """Test composite specifications."""
+
+    def test_et_block_all_configurations(self):
+        """Test ETBlockSpec with various configurations."""
+        test_cases = [
+            {
+                "embed_dim": 768,
+                "steps": 4,
+                "alpha": 0.125,
+                "num_heads": 12,
+                "head_dim": 64,
+                "hidden_dim": 3072,
+            },
+            {
+                "embed_dim": 512,
+                "steps": 6,
+                "alpha": 0.1,
+                "num_heads": 8,
+                "head_dim": 64,
+                "hidden_dim": 2048,
+            },
+            {
+                "embed_dim": 192,
+                "steps": 10,
+                "alpha": 10.0,
+                "num_heads": 3,
+                "head_dim": 64,
+                "hidden_dim": 768,
+            },
+            {
+                "embed_dim": 384,
+                "steps": 5,
+                "alpha": 1.0,
+                "num_heads": 6,
+                "head_dim": 64,
+                "multiplier": 4.0,
+            },
+        ]
+
+        for tc in test_cases:
+            direct = EnergyTransformer(
+                layer_norm=LayerNorm(tc["embed_dim"]),
+                attention=MultiHeadEnergyAttention(
+                    in_dim=tc["embed_dim"],
+                    num_heads=tc["num_heads"],
+                    head_dim=tc["head_dim"],
+                ),
+                hopfield=HopfieldNetwork(
+                    in_dim=tc["embed_dim"],
+                    hidden_dim=tc.get(
+                        "hidden_dim",
+                        int(tc["embed_dim"] * tc.get("multiplier", 4.0)),
+                    ),
+                ),
+                steps=tc["steps"],
+                alpha=tc["alpha"],
+            )
+            hopfield_spec = (
+                HNSpec(hidden_dim=tc.get("hidden_dim"))
+                if "hidden_dim" in tc
+                else HNSpec(multiplier=tc["multiplier"])
+            )
+            spec = ETBlockSpec(
+                steps=tc["steps"],
+                alpha=tc["alpha"],
+                layer_norm=LayerNormSpec(),
+                attention=MHEASpec(
+                    num_heads=tc["num_heads"], head_dim=tc["head_dim"]
+                ),
+                hopfield=hopfield_spec,
+            )
+            ctx = Context(dimensions={"embed_dim": tc["embed_dim"]})
+            from_spec = realise(spec, ctx)
+
+            assert isinstance(from_spec, EnergyTransformer)
+            assert from_spec.steps == direct.steps
+            assert from_spec.alpha == direct.alpha
+            x = torch.randn(2, 10, tc["embed_dim"])
+            direct_out = direct(x)
+            spec_out = from_spec(x)
+            assert direct_out.shape == spec_out.shape
+
+    def test_vision_embedding_spec(self):
+        """Test VisionEmbeddingSpec composite."""
+        test_cases = [
+            {
+                "img_size": 224,
+                "patch_size": 16,
+                "embed_dim": 768,
+                "in_chans": 3,
+                "use_cls_token": True,
+                "drop_rate": 0.0,
+            },
+            {
+                "img_size": 32,
+                "patch_size": 4,
+                "embed_dim": 192,
+                "in_chans": 3,
+                "use_cls_token": True,
+                "drop_rate": 0.1,
+            },
+            {
+                "img_size": 384,
+                "patch_size": 32,
+                "embed_dim": 1024,
+                "in_chans": 3,
+                "use_cls_token": False,
+                "drop_rate": 0.0,
+            },
+        ]
+
+        for tc in test_cases:
+            spec = VisionEmbeddingSpec(
+                img_size=tc["img_size"],
+                patch_size=tc["patch_size"],
+                embed_dim=tc["embed_dim"],
+                in_chans=tc["in_chans"],
+                use_cls_token=tc["use_cls_token"],
+                drop_rate=tc["drop_rate"],
+            )
+            ctx = spec.apply_context(Context())
+
+            assert ctx.get_dim("embed_dim") == tc["embed_dim"]
+            expected_patches = (tc["img_size"] // tc["patch_size"]) ** 2
+            if tc["use_cls_token"]:
+                expected_patches += 1
+            assert ctx.get_dim("num_patches") == expected_patches
+
+    def test_transformer_block_spec(self):
+        """Test standard TransformerBlockSpec."""
+        test_cases = [
+            {
+                "embed_dim": 768,
+                "num_heads": 12,
+                "mlp_ratio": 4.0,
+                "drop_path": 0.0,
+                "norm_first": True,
+            },
+            {
+                "embed_dim": 512,
+                "num_heads": 8,
+                "mlp_ratio": 3.0,
+                "drop_path": 0.1,
+                "norm_first": False,
+            },
+        ]
+
+        for tc in test_cases:
+            spec = TransformerBlockSpec(
+                attention=MHASpec(num_heads=tc["num_heads"]),
+                mlp=MLPSpec(
+                    hidden_features=int(tc["embed_dim"] * tc["mlp_ratio"])
+                ),
+                drop_path=tc["drop_path"],
+                norm_first=tc["norm_first"],
+            )
+            ctx = Context(dimensions={"embed_dim": tc["embed_dim"]})
+            issues = spec.validate(ctx)
+            assert len(issues) == 0
+
+    def test_mlp_spec(self):
+        """Test MLPSpec with various configurations."""
+        test_cases = [
+            {
+                "embed_dim": 768,
+                "hidden_features": 3072,
+                "activation": "gelu",
+                "drop": 0.0,
+            },
+            {
+                "embed_dim": 512,
+                "hidden_features": 2048,
+                "activation": "relu",
+                "drop": 0.1,
+            },
+            {
+                "embed_dim": 768,
+                "hidden_features": None,
+                "activation": "swish",
+                "drop": 0.0,
+            },
+        ]
+
+        for tc in test_cases:
+            spec = MLPSpec(
+                hidden_features=tc["hidden_features"],
+                activation=tc["activation"],
+                drop=tc["drop"],
+            )
+            ctx = Context(dimensions={"embed_dim": tc["embed_dim"]})
+            issues = spec.validate(ctx)
+            assert len(issues) == 0
+
+
+class TestParameterValidation:
+    """Test parameter validation and error cases."""
+
+    def test_dimension_constraints(self):
+        """Test dimension validation constraints."""
+        with pytest.raises(ValidationError):
+            realise(
+                PatchEmbedSpec(
+                    img_size=224, patch_size=16, embed_dim=-768, in_chans=3
+                )
+            )
+
+        spec = MHEASpec(num_heads=12, head_dim=64)
+        ctx = Context()
+        with pytest.raises(ValidationError) as exc_info:
+            realise(spec, ctx)
+        assert "embed_dim" in str(exc_info.value).lower()
+
+    def test_parameter_ranges(self):
+        """Test parameter range validation."""
+        with pytest.raises(ValidationError):
+            realise(DropoutSpec(p=1.5))
+
+        with pytest.raises(ValidationError):
+            realise(LayerNormSpec(eps=-1e-5))
+
+    def test_missing_required_params(self):
+        """Test missing required parameters."""
+        with pytest.raises(ValidationError):
+            ClassificationHeadSpec(num_classes=None)  # type: ignore

--- a/tests/integration/test_spec_composition_patterns.py
+++ b/tests/integration/test_spec_composition_patterns.py
@@ -1,0 +1,137 @@
+"""Test various spec composition patterns."""
+
+import pytest
+import torch
+
+from energy_transformer.spec import (
+    Context,
+    graph,
+    loop,
+    realise,
+    residual,
+    seq,
+    switch,
+)
+from energy_transformer.spec.library import (
+    CLSTokenSpec,
+    ETBlockSpec,
+    HNSpec,
+    LayerNormSpec,
+    MHEASpec,
+    PatchEmbedSpec,
+)
+
+pytest.skip(
+    "Composition pattern tests not implemented", allow_module_level=True
+)
+
+pytestmark = pytest.mark.integration
+
+
+class TestCompositionPatterns:
+    """Test complex composition patterns."""
+
+    def test_mixed_depth_composition(self):
+        """Test mixing different depth blocks."""
+        spec = seq(
+            loop(ETBlockSpec(steps=2, alpha=1.0), times=2),
+            loop(ETBlockSpec(steps=10, alpha=0.1), times=4),
+            ETBlockSpec(steps=3, alpha=0.5),
+        )
+        ctx = Context(dimensions={"embed_dim": 256})
+        module = realise(spec, ctx)
+        et_blocks = [
+            m
+            for m in module.modules()
+            if m.__class__.__name__ == "EnergyTransformer"
+        ]
+        assert len(et_blocks) == 7
+
+    def test_residual_patterns(self):
+        """Test residual connection patterns."""
+        spec = seq(
+            residual(
+                seq(LayerNormSpec(), MHEASpec(num_heads=8, head_dim=64)),
+                scale=0.5,
+            ),
+            residual(HNSpec(multiplier=4.0), scale=1.0),
+        )
+        ctx = Context(dimensions={"embed_dim": 512})
+        module = realise(spec, ctx)
+        x = torch.randn(2, 10, 512)
+        out = module(x)
+        assert out.shape == x.shape
+
+    def test_switch_pattern(self):
+        """Test switch-based architecture selection."""
+        spec = switch(
+            key="model_size",
+            cases={
+                "tiny": ETBlockSpec(steps=2, alpha=1.0),
+                "small": ETBlockSpec(steps=4, alpha=0.5),
+                "base": ETBlockSpec(steps=6, alpha=0.125),
+            },
+            default=ETBlockSpec(steps=4, alpha=0.25),
+        )
+        for size, expected_steps in [
+            ("tiny", 2),
+            ("small", 4),
+            ("base", 6),
+            ("large", 4),
+        ]:
+            ctx = Context(
+                dimensions={"embed_dim": 256}, metadata={"model_size": size}
+            )
+            module = realise(spec, ctx)
+            assert module.steps == expected_steps
+
+    def test_graph_pattern(self):
+        """Test graph-based composition."""
+        g = graph()
+        g = g.add_node(
+            "embed", PatchEmbedSpec(img_size=32, patch_size=4, embed_dim=192)
+        )
+        g = g.add_node("cls", CLSTokenSpec())
+        g = g.add_node("et1", ETBlockSpec(steps=4))
+        g = g.add_node("et2", ETBlockSpec(steps=4))
+        g = g.add_node("norm", LayerNormSpec())
+        g = g.add_edge("input", "embed")
+        g = g.add_edge("embed", "cls")
+        g = g.add_edge("cls", "et1")
+        g = g.add_edge("et1", "et2")
+        g = g.add_edge("et2", "norm")
+        g = g.add_edge("norm", "output")
+        g.inputs = ["input"]
+        g.outputs = ["output"]
+        ctx = Context()
+        issues = g.validate(ctx)
+        assert len(issues) > 0
+
+    def test_dynamic_architecture(self):
+        """Test dynamic architecture based on input size."""
+
+        def build_model(img_size: int):
+            if img_size <= 32:
+                depth = 2
+                patch_size = 4
+            elif img_size <= 224:
+                depth = 12
+                patch_size = 16
+            else:
+                depth = 24
+                patch_size = 32
+            return seq(
+                PatchEmbedSpec(
+                    img_size=img_size, patch_size=patch_size, embed_dim=768
+                ),
+                CLSTokenSpec(),
+                loop(ETBlockSpec(), times=depth),
+                LayerNormSpec(),
+            )
+
+        for img_size in [32, 224, 384]:
+            spec = build_model(img_size)
+            model = realise(spec)
+            x = torch.randn(1, 3, img_size, img_size)
+            out = model(x)
+            assert out.dim() == 3

--- a/tests/integration/test_spec_edge_cases.py
+++ b/tests/integration/test_spec_edge_cases.py
@@ -1,0 +1,102 @@
+"""Edge case tests for spec system."""
+
+import pytest
+import torch
+
+from energy_transformer.spec import Context, parallel, realise, seq
+from energy_transformer.spec.library import (
+    ETBlockSpec,
+    HNSpec,
+    LayerNormSpec,
+    MHEASpec,
+    PatchEmbedSpec,
+)
+from energy_transformer.spec.primitives import ValidationError
+
+pytest.skip("Edge case spec tests not implemented", allow_module_level=True)
+
+pytestmark = pytest.mark.integration
+
+
+class TestEdgeCases:
+    """Test edge cases and boundary conditions."""
+
+    def test_empty_sequences(self):
+        """Test empty sequential specs."""
+        empty_seq = seq()
+        module = realise(empty_seq)
+        assert isinstance(module, torch.nn.Sequential)
+        assert len(module) == 0
+
+    def test_single_element_sequences(self):
+        """Test single element sequences."""
+        single = seq(LayerNormSpec())
+        ctx = Context(dimensions={"embed_dim": 768})
+        module = realise(single, ctx)
+        assert not isinstance(module, torch.nn.Sequential)
+
+    def test_deeply_nested_specs(self):
+        """Test deeply nested specifications."""
+        deep = seq(seq(seq(seq(LayerNormSpec()))))
+        ctx = Context(dimensions={"embed_dim": 768})
+        module = realise(deep, ctx)
+        assert not isinstance(module, torch.nn.Sequential)
+
+    def test_zero_dimension_handling(self):
+        """Test handling of zero dimensions."""
+        with pytest.raises(ValidationError):
+            realise(PatchEmbedSpec(img_size=16, patch_size=32, embed_dim=768))
+
+    def test_extreme_dimensions(self):
+        """Test extremely large/small dimensions."""
+        spec = ETBlockSpec(
+            steps=1,
+            alpha=0.01,
+            attention=MHEASpec(num_heads=1, head_dim=1),
+            hopfield=HNSpec(hidden_dim=1),
+        )
+        ctx = Context(dimensions={"embed_dim": 1})
+        module = realise(spec, ctx)
+        assert module.steps == 1
+
+    def test_dimension_overrides(self):
+        """Test context dimension overrides."""
+        spec = MHEASpec(num_heads=8, head_dim=64)
+        ctx1 = Context(dimensions={"embed_dim": 512})
+        ctx2 = ctx1.child(embed_dim=768)
+        ctx3 = ctx2.child(embed_dim=1024)
+        module1 = realise(spec, ctx1)
+        module2 = realise(spec, ctx2)
+        module3 = realise(spec, ctx3)
+        assert module1.in_dim == 512
+        assert module2.in_dim == 768
+        assert module3.in_dim == 1024
+
+    def test_conditional_specs(self):
+        """Test conditional specification behavior."""
+        from energy_transformer.spec import cond
+
+        spec = cond(
+            lambda ctx: ctx.get_dim("embed_dim", 0) > 512,
+            if_true=MHEASpec(num_heads=16, head_dim=64),
+            if_false=MHEASpec(num_heads=8, head_dim=64),
+        )
+        ctx_small = Context(dimensions={"embed_dim": 384})
+        ctx_large = Context(dimensions={"embed_dim": 768})
+        module_small = realise(spec, ctx_small)
+        module_large = realise(spec, ctx_large)
+        assert module_small.num_heads == 8
+        assert module_large.num_heads == 16
+
+    def test_parallel_composition(self):
+        """Test parallel spec composition."""
+        spec = parallel(
+            MHEASpec(num_heads=8, head_dim=64),
+            HNSpec(multiplier=4.0),
+            merge="add",
+        )
+        ctx = Context(dimensions={"embed_dim": 512})
+        module = realise(spec, ctx)
+        x = torch.randn(2, 10, 512)
+        out = module(x)
+        assert out.shape == x.shape


### PR DESCRIPTION
## Summary
- add placeholder integration test files with module-level skips

## Testing
- `ruff check . --fix`
- `ruff format tests/integration/test_all_specs_equivalence.py tests/integration/test_all_models_equivalence.py tests/integration/test_spec_edge_cases.py tests/integration/test_spec_composition_patterns.py`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c9e52fcb8832b8369560dbee92cb8