### PR TITLE
Enable vision model equivalence tests

### DIFF
--- a/energy_transformer/models/vision/viet.py
+++ b/energy_transformer/models/vision/viet.py
@@ -226,11 +226,12 @@ class VisionEnergyTransformer(nn.Module):  # type: ignore[misc]
         block_trajectories = []
 
         for et_block in self.et_blocks:
+            track_arg = et_kwargs.get("track", "both")
+            kw = {k: v for k, v in et_kwargs.items() if k != "track"}
             result = et_block(
                 x,
-                return_energy=True,
-                return_trajectory=True,
-                **et_kwargs,
+                track=track_arg,
+                **kw,
             )
             if hasattr(result, "tokens"):
                 x = result.tokens
@@ -330,6 +331,7 @@ def viet_tiny(**kwargs: Any) -> VisionEnergyTransformer:
         "hopfield_hidden_dim": 768,  # 4x embed_dim
         "et_steps": 4,
         "et_alpha": 0.125,
+        "in_chans": 3,
     }
     config.update(kwargs)
     return VisionEnergyTransformer(**config)
@@ -345,6 +347,7 @@ def viet_small(**kwargs: Any) -> VisionEnergyTransformer:
         "hopfield_hidden_dim": 1536,  # 4x embed_dim
         "et_steps": 4,
         "et_alpha": 0.125,
+        "in_chans": 3,
     }
     config.update(kwargs)
     return VisionEnergyTransformer(**config)
@@ -360,6 +363,7 @@ def viet_base(**kwargs: Any) -> VisionEnergyTransformer:
         "hopfield_hidden_dim": 3072,  # 4x embed_dim
         "et_steps": 4,
         "et_alpha": 0.125,
+        "in_chans": 3,
     }
     config.update(kwargs)
     return VisionEnergyTransformer(**config)
@@ -375,6 +379,7 @@ def viet_large(**kwargs: Any) -> VisionEnergyTransformer:
         "hopfield_hidden_dim": 4096,  # 4x embed_dim
         "et_steps": 4,
         "et_alpha": 0.125,
+        "in_chans": 3,
     }
     config.update(kwargs)
     return VisionEnergyTransformer(**config)

--- a/energy_transformer/models/vision/viset.py
+++ b/energy_transformer/models/vision/viset.py
@@ -253,6 +253,7 @@ def viset_tiny(**kwargs: Any) -> VisionSimplicialEnergyTransformer:
         "hopfield_hidden_dim": 768,  # 4x embed_dim
         "et_steps": 4,
         "et_alpha": 0.125,
+        "in_chans": 3,
         "use_topology": True,
         "simplex_budget": 0.15,
         "simplex_max_dim": 2,
@@ -272,6 +273,7 @@ def viset_small(**kwargs: Any) -> VisionSimplicialEnergyTransformer:
         "hopfield_hidden_dim": 1536,  # 4x embed_dim
         "et_steps": 4,
         "et_alpha": 0.125,
+        "in_chans": 3,
         "use_topology": True,
         "simplex_budget": 0.15,
         "simplex_max_dim": 2,
@@ -291,6 +293,7 @@ def viset_base(**kwargs: Any) -> VisionSimplicialEnergyTransformer:
         "hopfield_hidden_dim": 3072,  # 4x embed_dim
         "et_steps": 4,
         "et_alpha": 0.125,
+        "in_chans": 3,
         "use_topology": True,
         "simplex_budget": 0.15,
         "simplex_max_dim": 2,

--- a/energy_transformer/models/vision/vit.py
+++ b/energy_transformer/models/vision/vit.py
@@ -139,6 +139,12 @@ class VisionTransformer(nn.Module):  # type: ignore[misc]
         """Initialize VisionTransformer."""
         super().__init__()
 
+        # Store key config values for external access
+        self.embed_dim = embed_dim
+        self.num_classes = num_classes
+        self.depth = depth
+        self.img_size = img_size
+
         # Patch embedding
         self.patch_embed = PatchEmbedding(
             img_size=img_size,
@@ -377,6 +383,7 @@ def vit_tiny(**kwargs: Any) -> VisionTransformer:
         "depth": 12,
         "num_heads": 3,
         "mlp_ratio": 4.0,
+        "in_chans": 3,
     }
     config.update(kwargs)
     return VisionTransformer(**config)
@@ -389,6 +396,7 @@ def vit_small(**kwargs: Any) -> VisionTransformer:
         "depth": 12,
         "num_heads": 6,
         "mlp_ratio": 4.0,
+        "in_chans": 3,
     }
     config.update(kwargs)
     return VisionTransformer(**config)
@@ -401,6 +409,7 @@ def vit_base(**kwargs: Any) -> VisionTransformer:
         "depth": 12,
         "num_heads": 12,
         "mlp_ratio": 4.0,
+        "in_chans": 3,
     }
     config.update(kwargs)
     return VisionTransformer(**config)
@@ -413,6 +422,7 @@ def vit_large(**kwargs: Any) -> VisionTransformer:
         "depth": 24,
         "num_heads": 16,
         "mlp_ratio": 4.0,
+        "in_chans": 3,
     }
     config.update(kwargs)
     return VisionTransformer(**config)

--- a/energy_transformer/spec/realise.py
+++ b/energy_transformer/spec/realise.py
@@ -49,7 +49,7 @@ from .primitives import Context, Spec, SpecMeta, ValidationError
 EDGE_TUPLE_SIZE: int = 2
 MAX_STACK_PREVIEW: int = 5
 FULL_EDGE_SIZE: int = 3
-UNROLL_LIMIT: int = 4
+UNROLL_LIMIT: int = 12
 
 # Default mappings for auto-importing modules based on Spec names
 module_mappings = {

--- a/tests/integration/test_all_models_equivalence.py
+++ b/tests/integration/test_all_models_equivalence.py
@@ -41,8 +41,6 @@ from energy_transformer.spec.library import (
     TransformerBlockSpec,
 )
 
-pytest.skip("Exhaustive model tests not implemented", allow_module_level=True)
-
 pytestmark = pytest.mark.integration
 
 


### PR DESCRIPTION
## Summary
- activate `tests/integration/test_all_models_equivalence.py`
- store model attributes in `VisionTransformer`
- ensure wrapper builders supply `in_chans`
- preserve energy tracking args in `VisionEnergyTransformer`
- unroll ET blocks by default by raising `UNROLL_LIMIT`

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy .`
- `pytest tests/integration/test_all_models_equivalence.py -q`
- `pytest -q` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_683cae135518832bbeb552f04d74be2c