### PR TITLE
Fix LayerNorm realiser and add graph realisation tests

### DIFF
--- a/energy_transformer/layers/__init__.py
+++ b/energy_transformer/layers/__init__.py
@@ -36,22 +36,18 @@ from .embeddings import PatchEmbedding, PositionalEmbedding2D
 from .heads import ClassificationHead, FeatureHead
 from .hopfield import HopfieldNetwork
 from .layer_norm import LayerNorm
+from .mlp import MLP
 from .simplicial import SimplicialHopfieldNetwork
 from .tokens import CLSToken
 
 __all__ = [
-    # Tokens
+    "MLP",
     "CLSToken",
-    # Heads
     "ClassificationHead",
     "FeatureHead",
-    # Memory Networks
     "HopfieldNetwork",
-    # Normalization
     "LayerNorm",
-    # Attention
     "MultiHeadEnergyAttention",
-    # Embeddings
     "PatchEmbedding",
     "PositionalEmbedding2D",
     "SimplicialHopfieldNetwork",

--- a/energy_transformer/layers/mlp.py
+++ b/energy_transformer/layers/mlp.py
@@ -1,0 +1,37 @@
+"""MLP module for transformer blocks."""
+
+from torch import Tensor, nn
+
+
+class MLP(nn.Module):
+    """Feedforward network with configurable activation."""
+
+    def __init__(
+        self,
+        in_features: int,
+        hidden_features: int,
+        out_features: int,
+        activation: str = "gelu",
+        drop: float = 0.0,
+    ) -> None:
+        super().__init__()
+        self.fc1 = nn.Linear(in_features, hidden_features)
+        self.fc2 = nn.Linear(hidden_features, out_features)
+        self.drop = nn.Dropout(drop)
+
+        activations = {
+            "gelu": nn.GELU(),
+            "relu": nn.ReLU(),
+            "swish": nn.SiLU(),
+            "silu": nn.SiLU(),
+        }
+        self.act = activations.get(activation, nn.GELU())
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Forward pass."""
+        x = self.fc1(x)
+        x = self.act(x)
+        x = self.drop(x)
+        x = self.fc2(x)
+        x = self.drop(x)
+        return x  # noqa: RET504

--- a/tests/integration/test_all_specs_equivalence.py
+++ b/tests/integration/test_all_specs_equivalence.py
@@ -59,6 +59,7 @@ class TestLayerSpecs:
             from_spec = realise(spec, ctx)
 
             assert isinstance(from_spec, LayerNorm)
+            assert type(from_spec) is type(direct)
             assert from_spec.in_dim == direct.in_dim
             assert from_spec.eps == direct.eps
 

--- a/tests/integration/test_graph_patterns.py
+++ b/tests/integration/test_graph_patterns.py
@@ -1,0 +1,74 @@
+"""Test graph-based model construction."""
+
+import pytest
+import torch
+
+from energy_transformer.spec import Context, graph, realise
+from energy_transformer.spec.library import (
+    CLSTokenSpec,
+    ETBlockSpec,
+    IdentitySpec,
+    LayerNormSpec,
+    PatchEmbedSpec,
+    PosEmbedSpec,
+)
+
+pytestmark = pytest.mark.integration
+
+
+class TestGraphPatterns:
+    """Test graph-based architectural patterns."""
+
+    def test_simple_vision_graph(self):
+        """Test building a simple vision model with graph."""
+        g = graph()
+
+        g = g.add_node(
+            "patch", PatchEmbedSpec(img_size=32, patch_size=4, embed_dim=192)
+        )
+        g = g.add_node("cls", CLSTokenSpec())
+        g = g.add_node("pos", PosEmbedSpec(include_cls=True))
+        g = g.add_node("et", ETBlockSpec(steps=4, alpha=0.1))
+        g = g.add_node("norm", LayerNormSpec())
+
+        g = g.add_edge("input", "patch")
+        g = g.add_edge("patch", "cls")
+        g = g.add_edge("cls", "pos")
+        g = g.add_edge("pos", "et")
+        g = g.add_edge("et", "norm")
+
+        g.inputs = ["input"]
+        g.outputs = ["norm"]
+
+        ctx = Context(dimensions={"embed_dim": 192, "num_patches": 65})
+        model = realise(g, ctx)
+
+        x = torch.randn(2, 3, 32, 32)
+        out = model(x)
+
+        assert out.shape == (2, 65, 192)
+
+    def test_multi_path_graph(self):
+        """Test graph with multiple paths."""
+        g = graph()
+
+        g = g.add_node("split", IdentitySpec())
+        g = g.add_node("attn1", IdentitySpec())
+        g = g.add_node("attn2", IdentitySpec())
+        g = g.add_node("merge", IdentitySpec())
+
+        g = g.add_edge("input", "split")
+        g = g.add_edge("split", "attn1")
+        g = g.add_edge("split", "attn2")
+        g = g.add_edge("attn1", "merge")
+        g = g.add_edge("attn2", "merge")
+
+        g.inputs = ["input"]
+        g.outputs = ["merge"]
+
+        ctx = Context(dimensions={"embed_dim": 128})
+        model = realise(g, ctx)
+
+        x = torch.randn(2, 10, 128)
+        out = model(x)
+        assert out.shape == (2, 10, 256)


### PR DESCRIPTION
## Summary
- ensure LayerNormSpec uses custom implementation
- add MLP layer and register MLPSpec realiser
- support TransformerBlockSpec realisation
- improve Graph realisation logic
- add integration tests for graph patterns
- verify ViT spec builds via TransformerBlockSpec

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy .`
- `pytest tests/integration/test_all_models_equivalence.py tests/integration/test_all_specs_equivalence.py tests/integration/test_graph_patterns.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683cb6a20d70832b9f2c72a95fdf9ff8