### PR TITLE
Add centralised realisation constants

### DIFF
--- a/energy_transformer/spec/library.py
+++ b/energy_transformer/spec/library.py
@@ -49,6 +49,9 @@ MAX_DIM: int = 65536
 MAX_MULTIPLIER: float = 8.0
 MAX_COMPLEX_DIM: int = 3
 MAX_STEPS: int = 50
+DEFAULT_EPS: float = 1e-5
+DEFAULT_INIT_STD: float = 0.02
+DEFAULT_TEMPERATURE: float = 0.5
 
 
 # Utility functions
@@ -88,7 +91,7 @@ class LayerNormSpec(Spec):
         Epsilon for numerical stability
     """
 
-    eps: float = param(default=1e-5, validator=validate_positive)
+    eps: float = param(default=DEFAULT_EPS, validator=validate_positive)
 
 
 @dataclass(frozen=True)
@@ -181,7 +184,9 @@ class PosEmbedSpec(Spec):
     """
 
     include_cls: bool = param(default=False)
-    init_std: float = param(default=0.02, validator=validate_positive)
+    init_std: float = param(
+        default=DEFAULT_INIT_STD, validator=validate_positive
+    )
 
 
 @dataclass(frozen=True)
@@ -307,7 +312,9 @@ class SHNSpec(Spec):
     multiplier: float = param(
         default=4.0, validator=lambda x: 0 < x <= MAX_MULTIPLIER
     )
-    temperature: float = param(default=0.5, validator=validate_positive)
+    temperature: float = param(
+        default=DEFAULT_TEMPERATURE, validator=validate_positive
+    )
 
     def apply_context(self, context: Context) -> Context:
         """Apply simplicial Hopfield specification to context."""

--- a/tests/unit/spec/test_configuration.py
+++ b/tests/unit/spec/test_configuration.py
@@ -1,0 +1,49 @@
+"""Test configuration management."""
+
+from energy_transformer.spec import configure_realisation
+from energy_transformer.spec.realise import (
+    RealisationConstants,
+    _get_config,
+    _thread_local,
+)
+
+
+def test_configure_constants():
+    """Test configuring realisation constants."""
+    if hasattr(_thread_local, "config"):
+        delattr(_thread_local, "config")
+
+    configure_realisation(
+        MAX_RECURSION=200,
+        UNROLL_LIMIT=20,
+        DEFAULT_CACHE_SIZE=256,
+    )
+
+    config = _get_config()
+    assert config.constants.MAX_RECURSION == 200
+    assert config.constants.UNROLL_LIMIT == 20
+    assert config.constants.DEFAULT_CACHE_SIZE == 256
+
+    assert config.constants.MAX_STACK_PREVIEW == 5
+    assert config.constants.EDGE_TUPLE_SIZE == 2
+
+
+def test_configure_constants_object():
+    """Test configuring with RealisationConstants object."""
+    if hasattr(_thread_local, "config"):
+        delattr(_thread_local, "config")
+
+    custom_constants = RealisationConstants(
+        MAX_RECURSION=50,
+        MAX_STACK_PREVIEW=10,
+        UNROLL_LIMIT=5,
+        DEFAULT_CACHE_SIZE=64,
+    )
+
+    configure_realisation(constants=custom_constants)
+
+    config = _get_config()
+    assert config.constants.MAX_RECURSION == 50
+    assert config.constants.MAX_STACK_PREVIEW == 10
+    assert config.constants.UNROLL_LIMIT == 5
+    assert config.constants.DEFAULT_CACHE_SIZE == 64


### PR DESCRIPTION
## Summary
- centralise hard-coded constants in `RealisationConstants`
- allow overriding constants via `configure_realisation`
- integrate new constants with realiser implementation
- expose default hyperparameters in `library` module
- add tests for configuration of constants

## Testing
- `ruff check --fix energy_transformer/spec/realise.py energy_transformer/spec/library.py tests/unit/spec/test_configuration.py`
- `ruff format energy_transformer/spec/realise.py energy_transformer/spec/library.py tests/unit/spec/test_configuration.py`
- `pytest tests/unit -q`

------
https://chatgpt.com/codex/tasks/task_e_683cc751dbe0832b955ff5a0f071269c