### PR TITLE
Add centralised realisation constants

### DIFF
--- a/energy_transformer/spec/library.py
+++ b/energy_transformer/spec/library.py
@@ -49,6 +49,9 @@ MAX_DIM: int = 65536
 MAX_MULTIPLIER: float = 8.0
 MAX_COMPLEX_DIM: int = 3
 MAX_STEPS: int = 50
+DEFAULT_EPS: float = 1e-5
+DEFAULT_INIT_STD: float = 0.02
+DEFAULT_TEMPERATURE: float = 0.5
 
 
 # Utility functions
@@ -88,7 +91,7 @@ class LayerNormSpec(Spec):
         Epsilon for numerical stability
     """
 
-    eps: float = param(default=1e-5, validator=validate_positive)
+    eps: float = param(default=DEFAULT_EPS, validator=validate_positive)
 
 
 @dataclass(frozen=True)
@@ -181,7 +184,9 @@ class PosEmbedSpec(Spec):
     """
 
     include_cls: bool = param(default=False)
-    init_std: float = param(default=0.02, validator=validate_positive)
+    init_std: float = param(
+        default=DEFAULT_INIT_STD, validator=validate_positive
+    )
 
 
 @dataclass(frozen=True)
@@ -307,7 +312,9 @@ class SHNSpec(Spec):
     multiplier: float = param(
         default=4.0, validator=lambda x: 0 < x <= MAX_MULTIPLIER
     )
-    temperature: float = param(default=0.5, validator=validate_positive)
+    temperature: float = param(
+        default=DEFAULT_TEMPERATURE, validator=validate_positive
+    )
 
     def apply_context(self, context: Context) -> Context:
         """Apply simplicial Hopfield specification to context."""

--- a/energy_transformer/spec/realise.py
+++ b/energy_transformer/spec/realise.py
@@ -46,10 +46,25 @@ from .combinators import (
 )
 from .primitives import Context, Spec, SpecMeta, ValidationError
 
-EDGE_TUPLE_SIZE: int = 2
-MAX_STACK_PREVIEW: int = 5
-FULL_EDGE_SIZE: int = 3
-UNROLL_LIMIT: int = 12
+
+@dataclass
+class RealisationConstants:
+    """Configuration constants for the realisation system."""
+
+    # Stack and recursion limits
+    MAX_RECURSION: int = 100
+    MAX_STACK_PREVIEW: int = 5
+
+    # Graph processing
+    EDGE_TUPLE_SIZE: int = 2
+    FULL_EDGE_SIZE: int = 3
+
+    # Loop unrolling
+    UNROLL_LIMIT: int = 12
+
+    # Cache settings
+    DEFAULT_CACHE_SIZE: int = 128
+
 
 # Default mappings for auto-importing modules based on Spec names
 module_mappings = {
@@ -188,7 +203,17 @@ class ModuleCache:
         enabled : bool
             Whether caching is enabled
         """
-        self.max_size = max_size
+        if hasattr(_thread_local, "config"):
+            config = _get_config()
+            default_size = config.constants.DEFAULT_CACHE_SIZE
+        else:
+            default_size = RealisationConstants.DEFAULT_CACHE_SIZE
+
+        self.max_size = (
+            max_size
+            if max_size != RealisationConstants.DEFAULT_CACHE_SIZE
+            else default_size
+        )
         self.enabled = enabled
         self._cache: dict[tuple[Any, ...], nn.Module] = {}
         self._access_order: list[tuple[Any, ...]] = []
@@ -375,7 +400,10 @@ class RealiserConfig:
     warnings: bool = True
     auto_import: bool = True
     optimizations: bool = True
-    max_recursion: int = 100
+    max_recursion: int = 100  # Keep for backward compatibility
+    constants: RealisationConstants = field(
+        default_factory=RealisationConstants
+    )
 
 
 # Thread-local configuration
@@ -395,7 +423,14 @@ def configure_realisation(**kwargs: Any) -> None:
     Parameters
     ----------
     **kwargs : Any
-        Configuration options to set
+        Configuration options to set. Can include:
+        - cache: ModuleCache instance
+        - strict: bool for strict validation
+        - warnings: bool for warning messages
+        - auto_import: bool for automatic imports
+        - optimizations: bool for spec optimizations
+        - max_recursion: int for recursion limit
+        - constants: RealisationConstants for all constants
 
     Raises
     ------
@@ -403,6 +438,27 @@ def configure_realisation(**kwargs: Any) -> None:
         If unknown configuration option
     """
     config = _get_config()
+
+    # Handle constants specially
+    if "constants" in kwargs:
+        config.constants = kwargs.pop("constants")
+
+    constant_overrides = {}
+    for key in list(kwargs.keys()):
+        if hasattr(config.constants, key):
+            constant_overrides[key] = kwargs.pop(key)
+    if "max_recursion" in kwargs:
+        constant_overrides["MAX_RECURSION"] = kwargs.pop("max_recursion")
+
+    if constant_overrides:
+        current = config.constants
+        new_constants = RealisationConstants(
+            **{k: getattr(current, k) for k in current.__dataclass_fields__}
+        )
+        for k, v in constant_overrides.items():
+            setattr(new_constants, k, v)
+        config.constants = new_constants
+
     for key, value in kwargs.items():
         if hasattr(config, key):
             setattr(config, key, value)
@@ -473,10 +529,10 @@ class Realiser:
                 return cached
 
         # Enforce recursion limit only for uncached specs
-        if self._recursion_depth >= config.max_recursion:
+        if self._recursion_depth >= config.constants.MAX_RECURSION:
             stack_summary = self._get_stack_summary()
             raise RealisationError(
-                f"Maximum recursion depth ({config.max_recursion}) exceeded",
+                f"Maximum recursion depth ({config.constants.MAX_RECURSION}) exceeded",
                 spec=spec,
                 context=self.context,
                 suggestion=(
@@ -532,10 +588,11 @@ class Realiser:
         if not self._realiser_stack:
             return "Empty"
 
-        recent = self._realiser_stack[-MAX_STACK_PREVIEW:]
+        config = _get_config()
+        recent = self._realiser_stack[-config.constants.MAX_STACK_PREVIEW :]
         summary = " -> ".join(spec.__class__.__name__ for spec in recent)
-        if len(self._realiser_stack) > MAX_STACK_PREVIEW:
-            summary = f"... ({len(self._realiser_stack) - MAX_STACK_PREVIEW} more) -> {summary}"
+        if len(self._realiser_stack) > config.constants.MAX_STACK_PREVIEW:
+            summary = f"... ({len(self._realiser_stack) - config.constants.MAX_STACK_PREVIEW} more) -> {summary}"
         return summary
 
     def _get_cycle_path(self, target_spec: Spec) -> list[str]:
@@ -911,11 +968,13 @@ class Realiser:
 
         from . import library  # Local import to avoid circular dependency
 
+        config = _get_config()
+
         if (
             not spec.unroll
             and isinstance(spec.body, library.ETBlockSpec)
             and isinstance(times, int)
-            and times <= UNROLL_LIMIT
+            and times <= config.constants.UNROLL_LIMIT
         ):
             return self._realise_unrolled_independent(spec, times)
 
@@ -1156,6 +1215,8 @@ class GraphModule(nn.Module):  # type: ignore[misc]
         """Construct adjacency and dependency data for the graph."""
         from collections import defaultdict
 
+        config = _get_config()
+
         adjacency: defaultdict[str, list[tuple[str, str | None]]] = defaultdict(
             list,
         )
@@ -1167,7 +1228,11 @@ class GraphModule(nn.Module):  # type: ignore[misc]
         for edge in self.edges:
             source = edge[0]
             target = edge[1]
-            transform = edge[2] if len(edge) == FULL_EDGE_SIZE else None
+            transform = (
+                edge[2]
+                if len(edge) == config.constants.FULL_EDGE_SIZE
+                else None
+            )
 
             if source in self.nodes or source in self.inputs:
                 adjacency[source].append((target, transform))

--- a/tests/unit/spec/test_configuration.py
+++ b/tests/unit/spec/test_configuration.py
@@ -1,0 +1,49 @@
+"""Test configuration management."""
+
+from energy_transformer.spec import configure_realisation
+from energy_transformer.spec.realise import (
+    RealisationConstants,
+    _get_config,
+    _thread_local,
+)
+
+
+def test_configure_constants():
+    """Test configuring realisation constants."""
+    if hasattr(_thread_local, "config"):
+        delattr(_thread_local, "config")
+
+    configure_realisation(
+        MAX_RECURSION=200,
+        UNROLL_LIMIT=20,
+        DEFAULT_CACHE_SIZE=256,
+    )
+
+    config = _get_config()
+    assert config.constants.MAX_RECURSION == 200
+    assert config.constants.UNROLL_LIMIT == 20
+    assert config.constants.DEFAULT_CACHE_SIZE == 256
+
+    assert config.constants.MAX_STACK_PREVIEW == 5
+    assert config.constants.EDGE_TUPLE_SIZE == 2
+
+
+def test_configure_constants_object():
+    """Test configuring with RealisationConstants object."""
+    if hasattr(_thread_local, "config"):
+        delattr(_thread_local, "config")
+
+    custom_constants = RealisationConstants(
+        MAX_RECURSION=50,
+        MAX_STACK_PREVIEW=10,
+        UNROLL_LIMIT=5,
+        DEFAULT_CACHE_SIZE=64,
+    )
+
+    configure_realisation(constants=custom_constants)
+
+    config = _get_config()
+    assert config.constants.MAX_RECURSION == 50
+    assert config.constants.MAX_STACK_PREVIEW == 10
+    assert config.constants.UNROLL_LIMIT == 5
+    assert config.constants.DEFAULT_CACHE_SIZE == 64


### PR DESCRIPTION
## Summary
- centralise hard-coded constants in `RealisationConstants`
- allow overriding constants via `configure_realisation`
- integrate new constants with realiser implementation
- expose default hyperparameters in `library` module
- add tests for configuration of constants
- fix unroll loop configuration usage

## Testing
- `ruff check energy_transformer/spec/realise.py energy_transformer/spec/library.py tests/unit/spec/test_configuration.py`
- `mypy energy_transformer/spec/realise.py`
- `pytest tests/unit -q`


------
https://chatgpt.com/codex/tasks/task_e_683cc751dbe0832b955ff5a0f071269c