### PR TITLE
Add performance metrics collection

### DIFF
--- a/energy_transformer/spec/__init__.py
+++ b/energy_transformer/spec/__init__.py
@@ -38,7 +38,7 @@ Example
 """
 
 from collections.abc import Callable
-from typing import TypeAlias
+from typing import Any, TypeAlias
 
 # Combinators
 from .combinators import (
@@ -65,6 +65,7 @@ from .combinators import (
     # Architectural patterns
     transformer_block,
 )
+from .metrics import MetricsCollector, RealisationMetrics
 
 # Core primitives
 from .primitives import (
@@ -144,6 +145,24 @@ def __getattr__(name: str) -> object:
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
+def get_realisation_metrics() -> dict[str, Any]:
+    """Get current realisation metrics."""
+    from .realise import _get_config
+
+    config = _get_config()
+    if config.metrics_collector.enabled:
+        return config.metrics_collector.get_metrics().get_summary()
+    return {}
+
+
+def reset_metrics() -> None:
+    """Reset realisation metrics."""
+    from .realise import _get_config
+
+    config = _get_config()
+    config.metrics_collector.reset()
+
+
 __all__ = [
     "REQUIRED",
     "AsyncSpec",
@@ -156,22 +175,22 @@ __all__ = [
     "Identity",
     "Lambda",
     "Loop",
+    "MetricsCollector",
     "ModuleCache",
     "Parallel",
     "RealisationError",
+    "RealisationMetrics",
     "Realiser",
     "RealiserPlugin",
     "Residual",
-    # --- Combinators ---
-    # Classes
     "Sequential",
-    # --- Core Primitives ---
     "Spec",
     "Switch",
     "ValidationError",
     "cond",
     "configure_realisation",
     "from_yaml",
+    "get_realisation_metrics",
     "graph",
     "loop",
     "mixture_of_experts",
@@ -181,18 +200,16 @@ __all__ = [
     "parallel",
     "param",
     "provides",
-    # --- Realisation ---
     "realise",
     "register",
     "register_typed",
     "requires",
+    "reset_metrics",
     "residual",
-    # Factory functions
     "seq",
     "spec",
     "switch",
     "to_yaml",
-    # Patterns
     "transformer_block",
     "validate_field",
     "visualize",

--- a/energy_transformer/spec/metrics.py
+++ b/energy_transformer/spec/metrics.py
@@ -1,0 +1,137 @@
+"""Performance metrics for the spec system."""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import defaultdict
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class RealisationMetrics:
+    """Metrics collected during spec realisation."""
+
+    # Timing metrics
+    total_time: float = 0.0
+    cache_lookup_time: float = 0.0
+    realisation_time: float = 0.0
+
+    # Count metrics
+    specs_realised: int = 0
+    cache_hits: int = 0
+    cache_misses: int = 0
+
+    # Complexity metrics
+    max_depth: int = 0
+
+    # Per-spec breakdown
+    spec_times: dict[str, list[float]] = field(default_factory=lambda: defaultdict(list))
+    spec_counts: dict[str, int] = field(default_factory=lambda: defaultdict(int))
+
+    def add_spec_time(self, spec_name: str, duration: float) -> None:
+        """Record time taken to realise a specific spec type."""
+        self.spec_times[spec_name].append(duration)
+        self.spec_counts[spec_name] += 1
+
+    def get_summary(self) -> dict[str, Any]:
+        """Get a summary of collected metrics."""
+        cache_total = self.cache_hits + self.cache_misses
+        summary = {
+            "total_time": self.total_time,
+            "specs_realised": self.specs_realised,
+            "cache_hit_rate": self.cache_hits / cache_total if cache_total > 0 else 0.0,
+            "avg_realisation_time": self.realisation_time / self.specs_realised if self.specs_realised > 0 else 0.0,
+            "max_depth": self.max_depth,
+        }
+
+        spec_stats: dict[str, dict[str, float | int]] = {}
+        for spec_name, times in self.spec_times.items():
+            if times:
+                spec_stats[spec_name] = {
+                    "count": self.spec_counts[spec_name],
+                    "avg_time": sum(times) / len(times),
+                    "min_time": min(times),
+                    "max_time": max(times),
+                }
+        summary["spec_stats"] = spec_stats
+        return summary
+
+
+class MetricsCollector:
+    """Thread-safe metrics collector."""
+
+    def __init__(self) -> None:
+        self._metrics = RealisationMetrics()
+        self._lock = threading.Lock()
+        self.enabled = False
+
+    @contextmanager
+    def timer(self, metric_name: str) -> Iterator[None]:
+        """Context manager for timing operations."""
+        if not self.enabled:
+            yield
+            return
+
+        start = time.perf_counter()
+        try:
+            yield
+        finally:
+            duration = time.perf_counter() - start
+            with self._lock:
+                current = getattr(self._metrics, metric_name, 0.0)
+                setattr(self._metrics, metric_name, current + duration)
+
+    @contextmanager
+    def spec_timer(self, spec_name: str) -> Iterator[None]:
+        """Context manager for timing spec realisation."""
+        if not self.enabled:
+            yield
+            return
+
+        start = time.perf_counter()
+        try:
+            yield
+        finally:
+            duration = time.perf_counter() - start
+            with self._lock:
+                self._metrics.add_spec_time(spec_name, duration)
+                self._metrics.specs_realised += 1
+                self._metrics.realisation_time += duration
+
+    def record_cache_hit(self) -> None:
+        """Record a cache hit."""
+        if not self.enabled:
+            return
+        with self._lock:
+            self._metrics.cache_hits += 1
+
+    def record_cache_miss(self) -> None:
+        """Record a cache miss."""
+        if not self.enabled:
+            return
+        with self._lock:
+            self._metrics.cache_misses += 1
+
+    def update_max_depth(self, depth: int) -> None:
+        """Update maximum recursion depth."""
+        if not self.enabled:
+            return
+        with self._lock:
+            self._metrics.max_depth = max(self._metrics.max_depth, depth)
+
+    def get_metrics(self) -> RealisationMetrics:
+        """Get a copy of current metrics."""
+        with self._lock:
+            import copy
+
+            return copy.deepcopy(self._metrics)
+
+    def reset(self) -> None:
+        """Reset all metrics."""
+        with self._lock:
+            self._metrics = RealisationMetrics()
+

--- a/tests/unit/spec/test_metrics.py
+++ b/tests/unit/spec/test_metrics.py
@@ -1,0 +1,67 @@
+"""Test metrics collection."""
+
+import pytest
+
+from energy_transformer.spec import (
+    configure_realisation,
+    get_realisation_metrics,
+    realise,
+    reset_metrics,
+    seq,
+)
+from energy_transformer.spec.library import ETBlockSpec, LayerNormSpec
+
+
+@pytest.mark.unit
+def test_metrics_collection() -> None:
+    """Test that metrics are collected when enabled."""
+    configure_realisation(enable_metrics=True)
+    reset_metrics()
+
+    spec = seq(
+        LayerNormSpec(),
+        ETBlockSpec(),
+        LayerNormSpec(),
+    )
+    realise(spec, embed_dim=768)
+
+    metrics = get_realisation_metrics()
+    assert metrics["specs_realised"] > 0
+    assert metrics["total_time"] > 0
+    assert "spec_stats" in metrics
+    assert "Sequential" in metrics["spec_stats"]
+    assert "LayerNormSpec" in metrics["spec_stats"]
+    assert "ETBlockSpec" in metrics["spec_stats"]
+
+    configure_realisation(enable_metrics=False)
+
+
+@pytest.mark.unit
+def test_metrics_disabled_by_default() -> None:
+    """Test that metrics return empty when disabled."""
+    configure_realisation(enable_metrics=False)
+    reset_metrics()
+
+    spec = ETBlockSpec()
+    realise(spec, embed_dim=768)
+
+    metrics = get_realisation_metrics()
+    assert metrics == {}
+
+
+@pytest.mark.unit
+def test_cache_metrics() -> None:
+    """Test cache hit/miss metrics."""
+    configure_realisation(enable_metrics=True)
+    reset_metrics()
+
+    spec = LayerNormSpec()
+    realise(spec, embed_dim=768)
+    realise(spec, embed_dim=768)
+
+    metrics = get_realisation_metrics()
+    assert metrics["cache_hit_rate"] > 0
+    assert metrics["specs_realised"] >= 1
+
+    configure_realisation(enable_metrics=False)
+


### PR DESCRIPTION
## Summary
- implement RealisationMetrics and MetricsCollector classes
- integrate metrics with realiser configuration and realisation process
- expose metrics functions in package API
- add unit tests for metrics collection

## Testing
- `ruff check energy_transformer/spec/__init__.py energy_transformer/spec/metrics.py energy_transformer/spec/realise.py tests/unit/spec/test_metrics.py`
- `pytest tests/unit/spec/test_metrics.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683cd2ce9524832b9b7a2cd2c0e3fcda