### PR TITLE
Add debug tracer for spec realisation

### DIFF
--- a/energy_transformer/spec/debug.py
+++ b/energy_transformer/spec/debug.py
@@ -1,8 +1,12 @@
 """Debug utilities for the realisation system."""
 
 import logging
+import time
+from collections import defaultdict, deque
 from collections.abc import Iterator
 from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Any
 
 from torch.nn import Module
 
@@ -10,13 +14,148 @@ from .primitives import Context, Spec
 from .realise import _get_config
 
 
+@dataclass
+class DebugEvent:
+    """A single debug event during realisation."""
+
+    timestamp: float
+    event_type: str  # "enter", "exit", "cache_hit", "error"
+    spec_type: str
+    spec_id: int
+    depth: int
+    duration: float | None = None
+    error: Exception | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class DebugTracer:
+    """Advanced debug tracer for spec realisation."""
+
+    def __init__(self, max_events: int = 10000) -> None:
+        self.events: deque[DebugEvent] = deque(maxlen=max_events)
+        self.spec_stack: list[tuple[Spec, float]] = []
+        self.enabled = False
+
+    def trace_enter(self, spec: Spec, depth: int, context: Context) -> None:
+        """Record spec realisation entry."""
+        if not self.enabled:
+            return
+
+        event = DebugEvent(
+            timestamp=time.perf_counter(),
+            event_type="enter",
+            spec_type=spec.__class__.__name__,
+            spec_id=id(spec),
+            depth=depth,
+            metadata={"context_dims": dict(context.dimensions)},
+        )
+        self.events.append(event)
+        self.spec_stack.append((spec, event.timestamp))
+
+    def trace_exit(
+        self, spec: Spec, depth: int, module: Module | None = None
+    ) -> None:
+        """Record spec realisation exit."""
+        if not self.enabled:
+            return
+
+        start_time = None
+        for i in range(len(self.spec_stack) - 1, -1, -1):
+            if self.spec_stack[i][0] is spec:
+                _, start_time = self.spec_stack.pop(i)
+                break
+
+        duration = time.perf_counter() - start_time if start_time else None
+
+        event = DebugEvent(
+            timestamp=time.perf_counter(),
+            event_type="exit",
+            spec_type=spec.__class__.__name__,
+            spec_id=id(spec),
+            depth=depth,
+            duration=duration,
+            metadata={
+                "module_type": module.__class__.__name__ if module else None
+            },
+        )
+        self.events.append(event)
+
+    def trace_cache_hit(self, spec: Spec, depth: int) -> None:
+        """Record cache hit."""
+        if not self.enabled:
+            return
+
+        event = DebugEvent(
+            timestamp=time.perf_counter(),
+            event_type="cache_hit",
+            spec_type=spec.__class__.__name__,
+            spec_id=id(spec),
+            depth=depth,
+        )
+        self.events.append(event)
+
+    def trace_error(self, spec: Spec, depth: int, error: Exception) -> None:
+        """Record error during realisation."""
+        if not self.enabled:
+            return
+
+        event = DebugEvent(
+            timestamp=time.perf_counter(),
+            event_type="error",
+            spec_type=spec.__class__.__name__,
+            spec_id=id(spec),
+            depth=depth,
+            error=error,
+        )
+        self.events.append(event)
+
+    def print_summary(self) -> None:
+        """Print a summary of traced events."""
+        if not self.events:
+            print("No events traced")
+            return
+
+        spec_stats: dict[str, dict[str, Any]] = defaultdict(
+            lambda: {"count": 0, "total_time": 0.0, "errors": 0}
+        )
+        for event in self.events:
+            if event.event_type == "exit" and event.duration:
+                spec_stats[event.spec_type]["count"] += 1
+                spec_stats[event.spec_type]["total_time"] += event.duration
+            elif event.event_type == "error":
+                spec_stats[event.spec_type]["errors"] += 1
+
+        print("\n=== Realisation Trace Summary ===")
+        print(f"Total events: {len(self.events)}")
+        print(f"Unique specs: {len({e.spec_id for e in self.events})}")
+        print(f"Max depth: {max(e.depth for e in self.events)}")
+
+        if spec_stats:
+            print("\n--- Per Spec Type Statistics ---")
+            for spec_type, stats in sorted(
+                spec_stats.items(),
+                key=lambda x: x[1]["total_time"],
+                reverse=True,
+            ):
+                if stats["count"] > 0:
+                    avg_time = stats["total_time"] / stats["count"]
+                    print(
+                        f"{spec_type:30} | Count: {stats['count']:5} | Total: {stats['total_time']:8.3f}s | Avg: {avg_time:8.5f}s | Errors: {stats['errors']}"
+                    )
+
+    def get_trace_events(self) -> list[DebugEvent]:
+        """Get copy of trace events."""
+        return list(self.events)
+
+
 @contextmanager
 def debug_realisation(
     log_level: int = logging.DEBUG,
     break_on_error: bool = False,
     trace_cache: bool = True,
+    trace_realisation: bool = False,
     _trace_imports: bool = True,
-) -> Iterator[None]:
+) -> Iterator[DebugTracer | None]:
     """Context manager for debugging realisation issues."""
     logger = logging.getLogger("energy_transformer.spec")
     old_level = logger.level
@@ -33,6 +172,14 @@ def debug_realisation(
     config = _get_config()
     old_warnings = config.warnings
     config.warnings = True
+
+    tracer = None
+    old_tracer = None
+    if trace_realisation:
+        tracer = DebugTracer()
+        tracer.enabled = True
+        old_tracer = getattr(config, "debug_tracer", None)
+        config.debug_tracer = tracer
 
     if trace_cache:
         original_get = config.cache.get
@@ -57,7 +204,7 @@ def debug_realisation(
         config.cache.put = traced_put  # type: ignore[method-assign]
 
     try:
-        yield
+        yield tracer
     except Exception:
         if break_on_error:
             import pdb
@@ -68,6 +215,10 @@ def debug_realisation(
         logger.setLevel(old_level)
         logger.removeHandler(handler)
         config.warnings = old_warnings
+
+        if trace_realisation and tracer:
+            tracer.print_summary()
+            config.debug_tracer = old_tracer
 
         if trace_cache:
             config.cache.get = original_get  # type: ignore[method-assign]

--- a/energy_transformer/spec/realise.py
+++ b/energy_transformer/spec/realise.py
@@ -25,7 +25,14 @@ from collections import defaultdict, deque
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, Protocol, TypeVar, cast, get_type_hints
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Protocol,
+    TypeVar,
+    cast,
+    get_type_hints,
+)
 
 import torch
 from torch import nn
@@ -316,6 +323,7 @@ class AutoImporter:
 
 
 if TYPE_CHECKING:
+    from .debug import DebugTracer
     from .library import HNSpec, MHEASpec, SHNSpec
 
 __all__ = [
@@ -624,6 +632,7 @@ class RealiserConfig:
     metrics_collector: MetricsCollector = field(
         default_factory=MetricsCollector
     )
+    debug_tracer: "DebugTracer | None" = None  # noqa: UP037
 
 
 # Thread-local configuration
@@ -735,10 +744,14 @@ class Realiser:
             Lambda: lambda spec: LambdaModule(spec.fn, spec.name),
         }
 
-    def realise(self, spec: Spec) -> nn.Module:  # noqa: C901
-        """Realise a spec into a PyTorch module with metrics."""
+    def realise(self, spec: Spec) -> nn.Module:  # noqa: C901, PLR0912, PLR0915
+        """Realise a spec into a PyTorch module with metrics and debugging."""
         config = _get_config()
         metrics = config.metrics_collector
+        tracer = config.debug_tracer
+
+        if tracer:
+            tracer.trace_enter(spec, self._recursion_depth, self.context)
 
         start_time = time.perf_counter() if metrics.enabled else 0
 
@@ -747,6 +760,8 @@ class Realiser:
 
         if cached:
             metrics.record_cache_hit()
+            if tracer:
+                tracer.trace_cache_hit(spec, self._recursion_depth)
             if metrics.enabled:
                 config.metrics_collector._metrics.total_time += (
                     time.perf_counter() - start_time
@@ -760,6 +775,8 @@ class Realiser:
             spec = self._optimize_spec(spec)
             if cached := config.cache.get(spec, self.context):
                 metrics.record_cache_hit()
+                if tracer:
+                    tracer.trace_cache_hit(spec, self._recursion_depth)
                 if metrics.enabled:
                     config.metrics_collector._metrics.total_time += (
                         time.perf_counter() - start_time
@@ -800,8 +817,14 @@ class Realiser:
         try:
             with metrics.spec_timer(spec.__class__.__name__):
                 module = self._realise_impl(spec)
+
             config.cache.put(spec, self.context, module)
+
+            if tracer:
+                tracer.trace_exit(spec, self._recursion_depth, module)
         except Exception as e:
+            if tracer:
+                tracer.trace_error(spec, self._recursion_depth, e)
             if not isinstance(e, RealisationError):
                 raise RealisationError(
                     f"Realisation failed: {type(e).__name__}: {e}",

--- a/tests/unit/spec/test_debug_tracer.py
+++ b/tests/unit/spec/test_debug_tracer.py
@@ -1,0 +1,86 @@
+"""Test debug tracing functionality."""
+
+import pytest
+
+from energy_transformer.spec import Context, realise, seq
+from energy_transformer.spec.debug import debug_realisation
+from energy_transformer.spec.library import ETBlockSpec, LayerNormSpec
+from energy_transformer.spec.realise import RealisationError
+
+
+def test_debug_trace_basic() -> None:
+    """Test basic debug tracing."""
+    spec = seq(
+        LayerNormSpec(),
+        ETBlockSpec(),
+    )
+
+    with debug_realisation(trace_realisation=True) as tracer:
+        realise(spec, embed_dim=768)
+
+    events = tracer.get_trace_events()
+    assert len(events) > 0
+
+    enter_events = [e for e in events if e.event_type == "enter"]
+    exit_events = [e for e in events if e.event_type == "exit"]
+    assert len(enter_events) > 0
+    assert len(exit_events) > 0
+
+    spec_types = {e.spec_type for e in events}
+    assert "Sequential" in spec_types
+    assert "LayerNormSpec" in spec_types
+    assert "ETBlockSpec" in spec_types
+
+
+def test_debug_trace_cache_hits() -> None:
+    """Test debug tracing of cache hits."""
+    spec = LayerNormSpec()
+    ctx = Context(dimensions={"embed_dim": 768})
+
+    with debug_realisation(trace_realisation=True) as tracer:
+        realise(spec, ctx)
+        realise(spec, ctx)
+
+    events = tracer.get_trace_events()
+    cache_hits = [e for e in events if e.event_type == "cache_hit"]
+    assert len(cache_hits) >= 1
+
+
+def test_debug_trace_errors() -> None:
+    """Test debug tracing of errors."""
+    spec = ETBlockSpec()
+
+    # Disable strict validation so error occurs during realisation
+    from energy_transformer.spec import configure_realisation
+
+    configure_realisation(strict=False)
+    try:
+        with (
+            debug_realisation(trace_realisation=True) as tracer,
+            pytest.raises(RealisationError),
+        ):
+            realise(spec)
+
+        events = tracer.get_trace_events()
+        error_events = [e for e in events if e.event_type == "error"]
+        assert len(error_events) > 0
+    finally:
+        configure_realisation(strict=True)
+
+
+def test_debug_trace_timing() -> None:
+    """Test that timing information is recorded."""
+    spec = seq(
+        LayerNormSpec(),
+        LayerNormSpec(),
+    )
+
+    with debug_realisation(trace_realisation=True) as tracer:
+        realise(spec, embed_dim=768)
+
+    events = tracer.get_trace_events()
+    exit_events = [e for e in events if e.event_type == "exit"]
+    timed_events = [e for e in exit_events if e.duration is not None]
+    assert len(timed_events) > 0
+    for event in timed_events:
+        assert event.duration > 0


### PR DESCRIPTION
## Summary
- implement `DebugTracer` to record realisation events
- expose tracer through `debug_realisation` context manager
- store tracer in `RealiserConfig`
- instrument `Realiser.realise` with tracing hooks
- add tests covering tracer functionality

## Testing
- `ruff format .`
- `ruff check .`
- `mypy .`
- `pytest -q tests/unit/spec/test_debug_tracer.py`
- `pytest -q` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_683cd7cc87c0832bbebe840d18e601a4