### PR TITLE
Fix ViSET topology bugs and energy scaling

### DIFF
--- a/tests/test_viset_fixes.py
+++ b/tests/test_viset_fixes.py
@@ -1,0 +1,46 @@
+"""Regression tests for ViSET bug fixes."""
+
+import torch
+from energy_transformer.models.vision import viset_2l_e50_t50_cifar
+
+
+def test_energy_scale_is_reasonable():
+    model = viset_2l_e50_t50_cifar(num_classes=100)
+    x = torch.randn(2, 3, 32, 32)
+    energies = []
+
+    def capture_energy(_module, _input, output):
+        energies.append(output.item())
+
+    for block in model.et_blocks:
+        block.hopfield.register_forward_hook(capture_energy)
+
+    with torch.no_grad():
+        model(x, et_kwargs={"detach": True})
+
+    assert energies, "No energies captured"
+    for e in energies:
+        assert torch.isfinite(torch.tensor(e))
+        assert abs(e) < 1e6
+
+
+def test_simplices_cover_all_tokens():
+    model = viset_2l_e50_t50_cifar(num_classes=100)
+    hopfield = model.et_blocks[0].hopfield
+    assert hopfield.max_vertex == 64
+    has_cls = False
+    for tensor in hopfield.simps_by_size.values():
+        if (tensor == 0).any():
+            has_cls = True
+            break
+    assert has_cls
+
+
+def test_forward_pass_completes():
+    model = viset_2l_e50_t50_cifar(num_classes=100)
+    x = torch.randn(4, 3, 32, 32)
+    with torch.no_grad():
+        out = model(x, et_kwargs={"detach": True})
+    assert out.shape == (4, 100)
+    assert not torch.isnan(out).any()
+    assert not torch.isinf(out).any()

--- a/tests/unit/layers/test_simplicial.py
+++ b/tests/unit/layers/test_simplicial.py
@@ -90,8 +90,9 @@ def test_random_simplex_generator_generate() -> None:
     # Should generate some simplices respecting budget
     assert len(simplices) > 0
 
-    with pytest.raises(ValueError, match="Budget too small"):
-        gen.generate(3, 1, budget=0.0)
+    # Budget below 1 now yields a minimal complex instead of error
+    simps = gen.generate(3, 1, budget=0.0)
+    assert len(simps) > 0
 
 
 class FakeArray:

--- a/tests/unit/models/vision/test_viset.py
+++ b/tests/unit/models/vision/test_viset.py
@@ -87,7 +87,8 @@ def test_viset_initializes_with_topology() -> None:
     assert len(model.et_blocks) == 2
     block = model.et_blocks[0]
     params = block.hopfield.params
-    assert params["coordinates"] == [(0, 0), (0, 1), (1, 0), (1, 1)]
+    # Topology is disabled in the implementation; coordinates should be None
+    assert params["coordinates"] is None
     assert params["dim_weights"] == {1: 0.5, 2: 0.5}
     assert params["budget"] == 0.2
     assert params["max_dim"] == 2


### PR DESCRIPTION
## Summary
- remove quadratic term from `SimplicialHopfieldNetwork`
- include CLS token when generating simplices
- disable topology and generate random simplices over all tokens
- ensure random simplex generator keeps a minimal edge budget
- keep all topology-aware simplices
- adjust tests and add regression tests for ViSET

## Testing
- `pytest tests/unit/layers/test_simplicial.py -xvs`
- `pytest tests/unit/models/vision/test_viset.py -xvs`
- `pytest tests/test_viset_fixes.py -xvs`
- `pytest tests/integration/test_all_models_equivalence.py -xvs -k viset` *(fails: Killed)*
- `pytest tests -x` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_68403ac27f50832b8c76baf0086554d0