### PR TITLE
Remove custom base layer classes

### DIFF
--- a/energy_transformer/layers/attention.py
+++ b/energy_transformer/layers/attention.py
@@ -5,10 +5,8 @@ import math
 import torch
 from torch import Tensor, nn
 
-from .base import BaseEnergyAttention
 
-
-class MultiHeadEnergyAttention(BaseEnergyAttention):
+class MultiHeadEnergyAttention(nn.Module):
     """Multi-Head Energy Attention.
 
     Defines an energy function whose gradient

--- a/energy_transformer/layers/base.py
+++ b/energy_transformer/layers/base.py
@@ -1,125 +1,13 @@
-"""Base classes for Energy Transformer components."""
+"""Utility helpers for Energy Transformer layers."""
 
-from abc import ABC, abstractmethod
+from torch import Tensor
 
-from torch import Tensor, nn
-
-
-class BaseLayerNorm(nn.Module, ABC):  # type: ignore[misc]
-    """Base class for all layer normalization implementations.
-
-    Defines the interface required for layer normalization components
-    used in BaseEnergyTransformer. Layer normalization transforms input
-    tokens into a normalized representation suitable for energy computation.
-    """
-
-    @abstractmethod
-    def forward(self, x: Tensor) -> Tensor:
-        """Apply layer normalization to input tensor.
-
-        Parameters
-        ----------
-        x : Tensor
-            Input tensor of shape [..., N, D] where N is the number
-            of tokens and D is the input dimension
-
-        Returns
-        -------
-        Tensor
-            Normalized output tensor of shape [..., N, D]
-        """
-        raise NotImplementedError
-
-    def reset_parameters(self) -> None:
-        """Reset layer parameters to initial values.
-
-        Override in subclasses to provide specific initialization.
-        Default implementation does nothing.
-        """
-
-
-class BaseEnergyAttention(nn.Module, ABC):  # type: ignore[misc]
-    """Base class for all energy-based attention implementations.
-
-    Defines the interface required for attention components used
-    in BaseEnergyTransformer. Energy attention computes a scalar
-    energy value from normalized token representations.
-    """
-
-    @abstractmethod
-    def forward(self, g: Tensor) -> Tensor:  # scalar
-        """Compute attention energy from normalized tokens.
-
-        Parameters
-        ----------
-        g : Tensor
-            Normalized token tensor of shape [..., N, D] where N is
-            the number of tokens and D is the feature dimension
-
-        Returns
-        -------
-        Tensor
-            Scalar energy value (shape == ()) representing the attention energy
-        """
-        raise NotImplementedError
-
-    def reset_parameters(self) -> None:
-        """Reset layer parameters to initial values.
-
-        Override in subclasses to provide specific initialization.
-        Default implementation does nothing.
-        """
-
-
-class BaseHopfieldNetwork(nn.Module, ABC):  # type: ignore[misc]
-    """Base class for all Hopfield Network implementations.
-
-    All Hopfield Networks must implement the forward method
-    that computes energy given normalized token representations.
-    """
-
-    @abstractmethod
-    def forward(self, g: Tensor) -> Tensor:  # scalar
-        """Compute Hopfield Network energy.
-
-        Parameters
-        ----------
-        g : Tensor
-            Normalized input tensor of shape [..., N, D] where N is the number
-            of tokens and D is input dimension of each token
-
-        Returns
-        -------
-        Tensor
-            Scalar energy value (shape == ())
-        """
-        raise NotImplementedError
-
-    def reset_parameters(self) -> None:
-        """Reset network parameters to initial values.
-
-        Override in subclasses to provide specific initialization.
-        Default implementation does nothing.
-        """
+__all__ = ["_validate_scalar_energy"]
 
 
 def _validate_scalar_energy(energy: Tensor, component_name: str) -> None:
-    """Validate that energy tensor is a scalar.
-
-    Parameters
-    ----------
-    energy : Tensor
-        Energy tensor to validate
-    component_name : str
-        Name of component for error messages
-
-    Raises
-    ------
-    ValueError
-        If energy tensor is not a scalar
-    """
+    """Validate that ``energy`` is a scalar tensor."""
     if energy.dim() != 0:
         raise ValueError(
-            f"{component_name} must return scalar energy tensor, "
-            f"got shape {energy.shape}",
+            f"{component_name} must return scalar energy tensor, got shape {energy.shape}"
         )

--- a/energy_transformer/layers/hopfield.py
+++ b/energy_transformer/layers/hopfield.py
@@ -6,10 +6,8 @@ import torch
 import torch.nn.functional as F  # noqa: N812
 from torch import Tensor, nn
 
-from .base import BaseHopfieldNetwork
 
-
-class HopfieldNetwork(BaseHopfieldNetwork):
+class HopfieldNetwork(nn.Module):
     """Modern Hopfield Network with energy-based formulation.
 
     Parameters

--- a/energy_transformer/layers/layer_norm.py
+++ b/energy_transformer/layers/layer_norm.py
@@ -6,10 +6,8 @@ import torch
 import torch.nn.functional as F  # noqa: N812
 from torch import Tensor, nn
 
-from .base import BaseLayerNorm
 
-
-class LayerNorm(BaseLayerNorm):
+class LayerNorm(nn.Module):
     """Layer normalized token representation with strict energy interpretation.
 
     Parameters

--- a/energy_transformer/layers/simplicial.py
+++ b/energy_transformer/layers/simplicial.py
@@ -23,7 +23,6 @@ try:
 except ImportError:
     HAS_SCIPY = False
 
-from .base import BaseHopfieldNetwork
 
 __all__: Final = [
     "SimplicialHopfieldNetwork",
@@ -589,7 +588,7 @@ def _autogen_simps(
     return simplices
 
 
-class SimplicialHopfieldNetwork(BaseHopfieldNetwork):
+class SimplicialHopfieldNetwork(nn.Module):
     """Continuous Simplicial Hopfield Network with optional auto complex.
 
     This network extends the classical Hopfield model to operate on simplicial

--- a/energy_transformer/models/base.py
+++ b/energy_transformer/models/base.py
@@ -6,12 +6,6 @@ from typing import Literal, NamedTuple, cast
 import torch
 from torch import Tensor, nn
 
-from energy_transformer.layers.base import (
-    BaseEnergyAttention,
-    BaseHopfieldNetwork,
-    BaseLayerNorm,
-)
-
 __all__ = ["DescentMode", "ETOutput", "EnergyTransformer", "Track"]
 
 # Registry for model classes to enable lookups from realiser
@@ -60,11 +54,11 @@ class EnergyTransformer(nn.Module):  # type: ignore[misc]
 
     Parameters
     ----------
-    layer_norm : BaseLayerNorm
+    layer_norm : nn.Module
         Layer normalization component that transforms input tokens
-    attention : BaseEnergyAttention
+    attention : nn.Module
         Energy-based attention component
-    hopfield : BaseHopfieldNetwork
+    hopfield : nn.Module
         Hopfield network component for memory-based associations
     steps : int, optional
         Number of gradient descent steps T, by default 12
@@ -74,9 +68,9 @@ class EnergyTransformer(nn.Module):  # type: ignore[misc]
 
     def __init__(
         self,
-        layer_norm: BaseLayerNorm,
-        attention: BaseEnergyAttention,
-        hopfield: BaseHopfieldNetwork,
+        layer_norm: nn.Module,
+        attention: nn.Module,
+        hopfield: nn.Module,
         steps: int = 12,
         alpha: float = 1.0,
     ) -> None:

--- a/energy_transformer/spec/realise.py
+++ b/energy_transformer/spec/realise.py
@@ -1802,25 +1802,18 @@ from . import library  # noqa: E402
 @register(library.ETBlockSpec)
 def realise_et_block(spec: library.ETBlockSpec, context: Context) -> nn.Module:
     """Realise ``ETBlockSpec`` into an :class:`EnergyTransformer`."""
-    from typing import cast
-
-    from energy_transformer.layers.base import (
-        BaseEnergyAttention,
-        BaseHopfieldNetwork,
-        BaseLayerNorm,
-    )
     from energy_transformer.models import EnergyTransformer
 
     realiser = Realiser(context)
 
     context = spec.layer_norm.apply_context(context)
-    layer_norm = cast(BaseLayerNorm, realiser.realise(spec.layer_norm))
+    layer_norm = realiser.realise(spec.layer_norm)
 
     context = spec.attention.apply_context(context)
-    attention = cast(BaseEnergyAttention, realiser.realise(spec.attention))
+    attention = realiser.realise(spec.attention)
 
     context = spec.hopfield.apply_context(context)
-    hopfield = cast(BaseHopfieldNetwork, realiser.realise(spec.hopfield))
+    hopfield = realiser.realise(spec.hopfield)
 
     return EnergyTransformer(
         layer_norm=layer_norm,

--- a/tests/unit/layers/test_base.py
+++ b/tests/unit/layers/test_base.py
@@ -1,29 +1,34 @@
 import pytest
 import torch
+from torch import nn
 
-from energy_transformer.layers.base import (
-    BaseEnergyAttention,
-    BaseHopfieldNetwork,
-    BaseLayerNorm,
-    _validate_scalar_energy,
-)
+from energy_transformer.layers.base import _validate_scalar_energy
 
 pytestmark = pytest.mark.unit
 
 
-class DummyLayerNorm(BaseLayerNorm):
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+class DummyLayerNorm(nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
         return x * 2
 
+    def reset_parameters(self) -> None:  # type: ignore[override]
+        pass
 
-class DummyEnergyAttention(BaseEnergyAttention):
-    def forward(self, g: torch.Tensor) -> torch.Tensor:
+
+class DummyEnergyAttention(nn.Module):
+    def forward(self, g: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
         return g.sum()
 
+    def reset_parameters(self) -> None:  # type: ignore[override]
+        pass
 
-class DummyHopfieldNetwork(BaseHopfieldNetwork):
-    def forward(self, g: torch.Tensor) -> torch.Tensor:
+
+class DummyHopfieldNetwork(nn.Module):
+    def forward(self, g: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
         return g.mean()
+
+    def reset_parameters(self) -> None:  # type: ignore[override]
+        pass
 
 
 def test_validate_scalar_energy_accepts_scalar() -> None:

--- a/tests/unit/models/test_base.py
+++ b/tests/unit/models/test_base.py
@@ -1,32 +1,37 @@
 import pytest
 import torch
+from torch import nn
 
-from energy_transformer.layers.base import (
-    BaseEnergyAttention,
-    BaseHopfieldNetwork,
-    BaseLayerNorm,
-)
 from energy_transformer.models.base import EnergyTransformer, ETOutput
 
 pytestmark = pytest.mark.unit
 
 
-class DummyLayerNorm(BaseLayerNorm):
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+class DummyLayerNorm(nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
         # Ensure gradient tracking is preserved
         return x * 2.0
 
+    def reset_parameters(self) -> None:  # type: ignore[override]
+        pass
 
-class DummyEnergyAttention(BaseEnergyAttention):
-    def forward(self, g: torch.Tensor) -> torch.Tensor:
+
+class DummyEnergyAttention(nn.Module):
+    def forward(self, g: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
         # Use operations that preserve gradient tracking
         return torch.sum(g)
 
+    def reset_parameters(self) -> None:  # type: ignore[override]
+        pass
 
-class DummyHopfieldNetwork(BaseHopfieldNetwork):
-    def forward(self, g: torch.Tensor) -> torch.Tensor:
+
+class DummyHopfieldNetwork(nn.Module):
+    def forward(self, g: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
         # Use operations that preserve gradient tracking
         return torch.mean(g)
+
+    def reset_parameters(self) -> None:  # type: ignore[override]
+        pass
 
 
 def test_energy_combines_components() -> None:


### PR DESCRIPTION
## Summary
- remove `BaseLayerNorm`, `BaseEnergyAttention` and `BaseHopfieldNetwork`
- update layers to extend `nn.Module`
- adjust model/type hints and specification realiser
- simplify tests accordingly
- clean up unused imports

## Testing
- `poetry run ruff check . --fix`
- `poetry run ruff format .`
- `poetry run ruff check . --output-format=github`
- `poetry run mypy .`
- `poetry run pytest -q` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_6840a02bdcdc832babf43044c733301b