### PR TITLE
Introduce EnergyLayerNorm

### DIFF
--- a/energy_transformer/layers/__init__.py
+++ b/energy_transformer/layers/__init__.py
@@ -17,11 +17,11 @@ Example
 >>> # Build a simple Energy Transformer block
 >>> import torch
 >>> from energy_transformer.layers import (
-...     LayerNorm, MultiheadEnergyAttention, HopfieldNetwork
+...     EnergyLayerNorm, MultiheadEnergyAttention, HopfieldNetwork
 ... )
 >>>
 >>> # Create layers
->>> norm = LayerNorm(in_dim=768)
+>>> norm = EnergyLayerNorm(768)
 >>> attn = MultiheadEnergyAttention(embed_dim=768, num_heads=12)
 >>> hopfield = HopfieldNetwork(in_dim=768, hidden_dim=3072)
 >>>
@@ -35,7 +35,7 @@ from .attention import MultiheadEnergyAttention
 from .embeddings import PatchEmbedding, PositionalEmbedding2D
 from .heads import ClassificationHead, FeatureHead
 from .hopfield import HopfieldNetwork
-from .layer_norm import LayerNorm
+from .layer_norm import EnergyLayerNorm
 from .mlp import MLP
 from .simplicial import SimplicialHopfieldNetwork
 from .tokens import CLSToken
@@ -44,9 +44,9 @@ __all__ = [
     "MLP",
     "CLSToken",
     "ClassificationHead",
+    "EnergyLayerNorm",
     "FeatureHead",
     "HopfieldNetwork",
-    "LayerNorm",
     "MultiheadEnergyAttention",
     "PatchEmbedding",
     "PositionalEmbedding2D",

--- a/energy_transformer/models/__init__.py
+++ b/energy_transformer/models/__init__.py
@@ -27,12 +27,12 @@ Example
 >>> import torch
 >>> from energy_transformer.models import EnergyTransformer
 >>> from energy_transformer.layers import (
-...     LayerNorm, MultiheadEnergyAttention, HopfieldNetwork
+...     EnergyLayerNorm, MultiheadEnergyAttention, HopfieldNetwork
 ... )
 >>>
 >>> # Create an Energy Transformer block
 >>> et_block = EnergyTransformer(
-...     layer_norm=LayerNorm(768),
+...     layer_norm=EnergyLayerNorm(768),
 ...     attention=MultiheadEnergyAttention(embed_dim=768, num_heads=12),
 ...     hopfield=HopfieldNetwork(768, hidden_dim=3072),
 ...     steps=4,

--- a/energy_transformer/models/base.py
+++ b/energy_transformer/models/base.py
@@ -98,7 +98,7 @@ class EnergyTransformer(nn.Module):  # type: ignore[misc]
         Tensor
             Scalar energy value E^TOTAL
         """
-        # g = LayerNorm(x): x ∈ ℝᴺˣᴰ → g ∈ ℝᴺˣᴷ
+        # g = EnergyLayerNorm(x): x ∈ ℝᴺˣᴰ → g ∈ ℝᴺˣᴷ
         g = self.layer_norm(x)
 
         # E^ATT = attention(g, mask)

--- a/energy_transformer/models/vision/viet.py
+++ b/energy_transformer/models/vision/viet.py
@@ -63,7 +63,7 @@ from energy_transformer.layers.embeddings import (
 )
 from energy_transformer.layers.heads import ClassificationHead
 from energy_transformer.layers.hopfield import HopfieldNetwork
-from energy_transformer.layers.layer_norm import LayerNorm
+from energy_transformer.layers.layer_norm import EnergyLayerNorm
 from energy_transformer.layers.tokens import CLSToken
 from energy_transformer.models.base import EnergyTransformer
 
@@ -160,7 +160,7 @@ class VisionEnergyTransformer(nn.Module):  # type: ignore[misc]
         self.et_blocks = nn.ModuleList(
             [
                 EnergyTransformer(
-                    layer_norm=LayerNorm(embed_dim),
+                    layer_norm=EnergyLayerNorm(embed_dim),
                     attention=MultiheadEnergyAttention(
                         embed_dim=embed_dim,
                         num_heads=num_heads,
@@ -177,7 +177,7 @@ class VisionEnergyTransformer(nn.Module):  # type: ignore[misc]
         )
 
         # Final layer normalization
-        self.norm = LayerNorm(embed_dim)
+        self.norm = EnergyLayerNorm(embed_dim)
 
         # Classification head
         self.head = ClassificationHead(

--- a/energy_transformer/models/vision/viset.py
+++ b/energy_transformer/models/vision/viset.py
@@ -64,7 +64,7 @@ from typing import Any
 from torch import nn
 
 from energy_transformer.layers.attention import MultiheadEnergyAttention
-from energy_transformer.layers.layer_norm import LayerNorm
+from energy_transformer.layers.layer_norm import EnergyLayerNorm
 from energy_transformer.layers.simplicial import SimplicialHopfieldNetwork
 from energy_transformer.models.base import EnergyTransformer
 from energy_transformer.models.vision.viet import VisionEnergyTransformer
@@ -216,7 +216,7 @@ class VisionSimplicialEnergyTransformer(VisionEnergyTransformer):
         self.et_blocks = nn.ModuleList(
             [
                 EnergyTransformer(
-                    layer_norm=LayerNorm(embed_dim),
+                    layer_norm=EnergyLayerNorm(embed_dim),
                     attention=MultiheadEnergyAttention(
                         embed_dim=embed_dim,
                         num_heads=num_heads,

--- a/energy_transformer/spec/realise.py
+++ b/energy_transformer/spec/realise.py
@@ -73,7 +73,7 @@ class RealisationConstants:
 
 # Default mappings for auto-importing modules based on Spec names
 module_mappings = {
-    "LayerNormSpec": ("energy_transformer.layers", "LayerNorm"),
+    "LayerNormSpec": ("energy_transformer.layers", "EnergyLayerNorm"),
     "PatchEmbedSpec": (
         "energy_transformer.layers.embeddings",
         "PatchEmbedding",
@@ -1869,7 +1869,7 @@ def realise_layer_norm(
     context: Context,
 ) -> nn.Module:
     """Realise layer normalization using custom implementation."""
-    from energy_transformer.layers import LayerNorm
+    from energy_transformer.layers import EnergyLayerNorm
 
     embed_dim = context.get_dim("embed_dim")
     if embed_dim is None:
@@ -1879,7 +1879,7 @@ def realise_layer_norm(
             context=context,
         )
 
-    return LayerNorm(in_dim=embed_dim, eps=spec.eps)
+    return EnergyLayerNorm(embed_dim, eps=spec.eps)
 
 
 @register(library.ClassificationHeadSpec)

--- a/tests/integration/test_all_specs_equivalence.py
+++ b/tests/integration/test_all_specs_equivalence.py
@@ -62,7 +62,7 @@ class TestLayerSpecs:
 
             assert isinstance(from_spec, EnergyLayerNorm)
             assert type(from_spec) is type(direct)
-            assert from_spec.in_dim == direct.in_dim
+            assert from_spec.normalized_shape == direct.normalized_shape
             assert from_spec.eps == direct.eps
 
             x = torch.randn(2, 10, tc["embed_dim"])

--- a/tests/integration/test_all_specs_equivalence.py
+++ b/tests/integration/test_all_specs_equivalence.py
@@ -9,9 +9,9 @@ from torch import nn
 from energy_transformer.layers import (
     ClassificationHead,
     CLSToken,
+    EnergyLayerNorm,
     FeatureHead,
     HopfieldNetwork,
-    LayerNorm,
     MultiheadEnergyAttention,
     PatchEmbedding,
     PositionalEmbedding2D,
@@ -55,12 +55,12 @@ class TestLayerSpecs:
         ]
 
         for tc in test_cases:
-            direct = LayerNorm(in_dim=tc["embed_dim"], eps=tc["eps"])
+            direct = EnergyLayerNorm(tc["embed_dim"], eps=tc["eps"])
             spec = LayerNormSpec(eps=tc["eps"])
             ctx = Context(dimensions={"embed_dim": tc["embed_dim"]})
             from_spec = realise(spec, ctx)
 
-            assert isinstance(from_spec, LayerNorm)
+            assert isinstance(from_spec, EnergyLayerNorm)
             assert type(from_spec) is type(direct)
             assert from_spec.in_dim == direct.in_dim
             assert from_spec.eps == direct.eps
@@ -641,7 +641,7 @@ class TestCompositeSpecs:
 
         for tc in test_cases:
             direct = EnergyTransformer(
-                layer_norm=LayerNorm(tc["embed_dim"]),
+                layer_norm=EnergyLayerNorm(tc["embed_dim"]),
                 attention=MultiheadEnergyAttention(
                     embed_dim=tc["embed_dim"],
                     num_heads=tc["num_heads"],

--- a/tests/integration/test_spec_model_equivalence.py
+++ b/tests/integration/test_spec_model_equivalence.py
@@ -6,8 +6,8 @@ import torch
 from energy_transformer.layers import (
     ClassificationHead,
     CLSToken,
+    EnergyLayerNorm,
     HopfieldNetwork,
-    LayerNorm,
     MultiheadEnergyAttention,
     PatchEmbedding,
     PositionalEmbedding2D,
@@ -131,11 +131,11 @@ class TestComponentEquivalence:
         assert from_spec2.hidden_dim == 3072
 
     def test_layer_norm_equivalence(self):
-        """LayerNormSpec should produce identical LayerNorm."""
+        """LayerNormSpec should produce identical EnergyLayerNorm."""
         spec = LayerNormSpec(eps=1e-5)
         ctx = Context(dimensions={"embed_dim": 768})
         from_spec = realise(spec, ctx)
-        assert isinstance(from_spec, LayerNorm)
+        assert isinstance(from_spec, EnergyLayerNorm)
 
     def test_classification_head_equivalence(self):
         """ClassificationHeadSpec should produce identical ClassificationHead."""
@@ -167,7 +167,7 @@ class TestETBlockEquivalence:
         """ETBlockSpec should produce identical EnergyTransformer."""
         embed_dim = 768
         direct = EnergyTransformer(
-            layer_norm=LayerNorm(embed_dim),
+            layer_norm=EnergyLayerNorm(embed_dim),
             attention=MultiheadEnergyAttention(
                 embed_dim=embed_dim,
                 num_heads=12,

--- a/tests/performance/test_component_speed.py
+++ b/tests/performance/test_component_speed.py
@@ -6,8 +6,8 @@ import pytest
 import torch
 
 from energy_transformer.layers import (
+    EnergyLayerNorm,
     HopfieldNetwork,
-    LayerNorm,
     MultiheadEnergyAttention,
     PatchEmbedding,
     SimplicialHopfieldNetwork,
@@ -348,7 +348,7 @@ class TestEnergyTransformerBlock:
 
         et_block = (
             EnergyTransformer(
-                layer_norm=LayerNorm(embed_dim),
+                layer_norm=EnergyLayerNorm(embed_dim),
                 attention=MultiheadEnergyAttention(
                     embed_dim=embed_dim,
                     num_heads=num_heads,
@@ -403,7 +403,7 @@ class TestEnergyTransformerBlock:
 
         et_block = (
             EnergyTransformer(
-                layer_norm=LayerNorm(embed_dim),
+                layer_norm=EnergyLayerNorm(embed_dim),
                 attention=MultiheadEnergyAttention(
                     embed_dim=embed_dim,
                     num_heads=num_heads,

--- a/tests/performance/test_memory_usage.py
+++ b/tests/performance/test_memory_usage.py
@@ -7,8 +7,8 @@ import pytest
 import torch
 
 from energy_transformer.layers import (
+    EnergyLayerNorm,
     HopfieldNetwork,
-    LayerNorm,
     MultiheadEnergyAttention,
     SimplicialHopfieldNetwork,
 )
@@ -345,7 +345,7 @@ class TestComponentMemory:
         batch_size = 32
         seq_len = 256
 
-        energy_ln = LayerNorm(embed_dim).to(device).eval()
+        energy_ln = EnergyLayerNorm(embed_dim).to(device).eval()
         standard_ln = torch.nn.LayerNorm(embed_dim).to(device).eval()
 
         x = torch.randn(batch_size, seq_len, embed_dim, device=device)

--- a/tests/unit/models/vision/test_viset.py
+++ b/tests/unit/models/vision/test_viset.py
@@ -58,7 +58,7 @@ class DummySimplicialHopfieldNetwork(nn.Module):
 @pytest.fixture(autouse=True)
 def patch_components(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(viset, "EnergyTransformer", DummyEnergyTransformer)
-    monkeypatch.setattr(viset, "LayerNorm", DummyLayerNorm)
+    monkeypatch.setattr(viset, "EnergyLayerNorm", DummyLayerNorm)
     monkeypatch.setattr(viset, "MultiheadEnergyAttention", DummyAttention)
     monkeypatch.setattr(
         viset,


### PR DESCRIPTION
## Summary
- implement new `EnergyLayerNorm` and remove old `LayerNorm`
- update imports and documentation to use `EnergyLayerNorm`
- adapt tests for renamed API

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy .`


------
https://chatgpt.com/codex/tasks/task_e_6840c41cea00832b982fcbfce2379f5f