### PR TITLE
Fix legacy API breakages

### DIFF
--- a/energy_transformer/models/vision/viet.py
+++ b/energy_transformer/models/vision/viet.py
@@ -66,7 +66,6 @@ from energy_transformer.layers.heads import ClassifierHead
 from energy_transformer.layers.hopfield import HopfieldNetwork
 from energy_transformer.layers.layer_norm import EnergyLayerNorm
 from energy_transformer.models.base import EnergyTransformer
-from energy_transformer.utils.optimizers import SGD
 
 
 class VisionEnergyTransformer(nn.Module):  # type: ignore[misc]
@@ -171,7 +170,7 @@ class VisionEnergyTransformer(nn.Module):  # type: ignore[misc]
                         hidden_dim=hopfield_hidden_dim,
                     ),
                     steps=et_steps,
-                    optimizer=SGD(alpha=et_alpha),
+                    alpha=et_alpha,
                 )
                 for _ in range(depth)
             ],

--- a/energy_transformer/models/vision/viset.py
+++ b/energy_transformer/models/vision/viset.py
@@ -68,7 +68,6 @@ from energy_transformer.layers.layer_norm import EnergyLayerNorm
 from energy_transformer.layers.simplicial import SimplicialHopfieldNetwork
 from energy_transformer.models.base import EnergyTransformer
 from energy_transformer.models.vision.viet import VisionEnergyTransformer
-from energy_transformer.utils.optimizers import SGD
 
 
 class VisionSimplicialEnergyTransformer(VisionEnergyTransformer):
@@ -233,7 +232,7 @@ class VisionSimplicialEnergyTransformer(VisionEnergyTransformer):
                         hidden_dim=hopfield_hidden_dim,
                     ),
                     steps=et_steps,
-                    optimizer=SGD(alpha=et_alpha),
+                    alpha=et_alpha,
                 )
                 for _ in range(depth)
             ],

--- a/energy_transformer/spec/realise.py
+++ b/energy_transformer/spec/realise.py
@@ -1810,7 +1810,6 @@ from . import library  # noqa: E402
 def realise_et_block(spec: library.ETBlockSpec, context: Context) -> nn.Module:
     """Realise ``ETBlockSpec`` into an :class:`EnergyTransformer`."""
     from energy_transformer.models import EnergyTransformer
-    from energy_transformer.utils.optimizers import SGD
 
     realiser = Realiser(context)
 
@@ -1828,7 +1827,7 @@ def realise_et_block(spec: library.ETBlockSpec, context: Context) -> nn.Module:
         attention=attention,
         hopfield=hopfield,
         steps=spec.steps,
-        optimizer=SGD(alpha=spec.alpha),
+        alpha=spec.alpha,
     )
 
 


### PR DESCRIPTION
## Summary
- restore ETOutput container and classic EnergyTransformer API
- allow passing `alpha` again so specs build correctly
- update ViET and ViSET to use the restored interface
- adapt realise logic for ET blocks

## Testing
- `pytest tests/unit/models/test_base.py::test_forward_no_clone_preserves_input_and_grad -q`
- `pytest tests/unit/models/test_base.py::test_inference_mode_requires_detach -q`
- `pytest tests/unit/models/vision/test_viset.py::test_viset_initializes_with_topology -q`
- `pytest tests/unit/models/vision/test_viset.py::test_viset_without_topology_custom_weights -q`
- `pytest tests/unit/models/vision/test_viset.py::test_factory_functions_return_models -q`
- `pytest tests/integration/test_spec_model_equivalence.py::TestETBlockEquivalence::test_et_block_construction -q`
- `pytest tests/integration/test_spec_model_equivalence.py::TestModelBehavior::test_energy_minimization_occurs -q`
- `pytest tests/integration/test_all_models_equivalence.py::TestModelAttributes::test_energy_output_functionality -q`
- `pytest tests/integration/test_all_specs_equivalence.py::TestCompositeSpecs::test_et_block_all_configurations -q`
- `pytest tests/unit/models/vision/test_viet.py -q`
- `pytest tests/integration/test_spec_composition_patterns.py::TestCompositionPatterns::test_switch_pattern -q`
- `ruff check . --fix`
- `ruff format .`
- `mypy .`


------
https://chatgpt.com/codex/tasks/task_e_684192476b1c832b8b75dedd77a9556a