### PR TITLE
Refactor energy transformer layers

### DIFF
--- a/energy_transformer/layers/embeddings.py
+++ b/energy_transformer/layers/embeddings.py
@@ -33,7 +33,7 @@ def _to_pair(x: int | tuple[int, int]) -> tuple[int, int]:
     return (x, x)
 
 
-class ConvPatchEmbed(nn.Module):  # type: ignore[misc]
+class ConvPatchEmbed(nn.Module):
     """Convolutional patch embedding layer.
 
     Extracts non-overlapping patches and projects them to embedding dimension
@@ -133,13 +133,13 @@ class ConvPatchEmbed(nn.Module):  # type: ignore[misc]
             f"Input size width {w} doesn't match model {self.img_size[1]}"
         )
 
-        x = self.proj(x)  # (B, D, H/p, W/p)
+        x = self.proj(x)  # shape: [B, D, H/p, W/p]
         if self.flatten:
-            x = x.flatten(2).transpose(1, 2)  # (B, N, D)
+            x = x.flatten(2).transpose(1, 2)  # [B, N, D]
         return cast(Tensor, self.norm(x))
 
 
-class PatchifyEmbed(nn.Module):  # type: ignore[misc]
+class PatchifyEmbed(nn.Module):
     """Two-stage patch embedding with separate patchification and projection.
 
     First reshapes image into patches preserving spatial structure, then
@@ -247,7 +247,7 @@ class PatchifyEmbed(nn.Module):  # type: ignore[misc]
             gw=self.grid_size[1],
             ph=ph,
             pw=pw,
-        )
+        )  # shape: [B, N, C, pH, pW]
 
     def unpatchify(self, patches: Tensor) -> Tensor:
         """Reconstruct images from patches.
@@ -267,7 +267,7 @@ class PatchifyEmbed(nn.Module):  # type: ignore[misc]
             "b (gh gw) c ph pw -> b c (gh ph) (gw pw)",
             gh=self.grid_size[0],
             gw=self.grid_size[1],
-        )
+        )  # shape: [B, C, H, W]
 
     def forward(self, x: Tensor) -> Tensor:
         """Forward pass.
@@ -282,13 +282,13 @@ class PatchifyEmbed(nn.Module):  # type: ignore[misc]
         Tensor
             Output tensor of shape (B, N, D).
         """
-        x = self.patchify(x)  # (B, N, C, pH, pW)
-        x = rearrange(x, "b n c h w -> b n (c h w)")  # (B, N, patch_dim)
-        x = self.proj(x)  # (B, N, D)
+        x = self.patchify(x)  # shape: [B, N, C, pH, pW]
+        x = rearrange(x, "b n c h w -> b n (c h w)")  # [B, N, patch_dim]
+        x = self.proj(x)  # shape: [B, N, D]
         return cast(Tensor, self.norm(x))
 
 
-class PosEmbed2D(nn.Module):  # type: ignore[misc]
+class PosEmbed2D(nn.Module):
     """Learnable 2D positional embeddings.
 
     Supports both batched and unbatched inputs by storing positional

--- a/energy_transformer/layers/heads.py
+++ b/energy_transformer/layers/heads.py
@@ -41,7 +41,7 @@ def _create_pool(pool_type: str = "avg") -> nn.Module:
     raise ValueError(f"Unknown pool_type: {pool_type}")
 
 
-class ClassifierHead(nn.Module):  # type: ignore[misc]
+class ClassifierHead(nn.Module):
     """General purpose classifier head with pooling and dropout.
 
     Handles both spatial (CNN) and sequence (ViT) inputs with configurable
@@ -157,7 +157,7 @@ class ClassifierHead(nn.Module):  # type: ignore[misc]
         return x
 
 
-class LinearClassifierHead(nn.Module):  # type: ignore[misc]
+class LinearClassifierHead(nn.Module):
     """Simple linear classifier head.
 
     Minimal classifier head that just applies pooling, dropout, and
@@ -220,7 +220,7 @@ class LinearClassifierHead(nn.Module):  # type: ignore[misc]
         return cast(Tensor, self.fc(x))
 
 
-class NormMLPClassifierHead(nn.Module):  # type: ignore[misc]
+class NormMLPClassifierHead(nn.Module):
     """Norm + MLP classifier head.
 
     Classifier head with layer normalization and a two-layer MLP
@@ -311,7 +311,7 @@ class NormMLPClassifierHead(nn.Module):  # type: ignore[misc]
         return cast(Tensor, self.fc2(x))  # (B, num_classes)
 
 
-class NormLinearClassifierHead(nn.Module):  # type: ignore[misc]
+class NormLinearClassifierHead(nn.Module):
     """Normalized linear classifier head.
 
     Simple classifier with layer normalization followed by linear projection.
@@ -379,7 +379,7 @@ class NormLinearClassifierHead(nn.Module):  # type: ignore[misc]
         return cast(Tensor, self.fc(x))
 
 
-class ReLUMLPClassifierHead(nn.Module):  # type: ignore[misc]
+class ReLUMLPClassifierHead(nn.Module):
     """ReLU-based MLP classifier head.
 
     Two-layer MLP with ReLU activation, layer normalization,

--- a/energy_transformer/layers/mlp.py
+++ b/energy_transformer/layers/mlp.py
@@ -10,7 +10,7 @@ from torch import Tensor, nn
 __all__ = ["MLP"]
 
 
-class MLP(nn.Module):  # type: ignore[misc]
+class MLP(nn.Module):
     """MLP as used in Vision Transformer, MLP-Mixer and related networks.
 
     Standard two-layer MLP with configurable hidden dimension, activation,


### PR DESCRIPTION
## Summary
- refactor attention layer to exclude self-attention and clarify docs
- make Hopfield beta learnable and document theory
- expand EnergyLayerNorm math docs
- document energy minimization in base model
- clean up code, add shape comments, and apply PyTorch idioms

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy .`

------
https://chatgpt.com/codex/tasks/task_e_6841ab3d1710832b82d3acf33ef26385