### PR TITLE
Standardize validation across layers

### DIFF
--- a/energy_transformer/layers/heads.py
+++ b/energy_transformer/layers/heads.py
@@ -135,6 +135,12 @@ class ClassifierHead(nn.Module):
         Tensor
             Logits of shape (B, num_classes).
         """
+        if self.pool_type != PoolType.NONE and x.dim() not in [2, 3]:
+            raise ValueError(
+                f"{self.__class__.__name__}: Input must be 2D or 3D when pool_type='{self.pool_type}'. "
+                f"Got {x.dim()}D input with shape {list(x.shape)}."
+            )
+
         if self.pool_type == PoolType.TOKEN:
             # Extract CLS token
             x = x[:, 0]  # (B, C)
@@ -211,6 +217,12 @@ class LinearClassifierHead(nn.Module):
         Tensor
             Logits of shape (B, num_classes).
         """
+        if self.pool_type != PoolType.NONE and x.dim() not in [2, 3]:
+            raise ValueError(
+                f"{self.__class__.__name__}: Input must be 2D or 3D when pool_type='{self.pool_type}'. "
+                f"Got {x.dim()}D input with shape {list(x.shape)}."
+            )
+
         if x.ndim == 3:  # noqa: PLR2004
             if self.pool_type == PoolType.TOKEN:
                 x = x[:, 0]
@@ -297,6 +309,24 @@ class NormMLPClassifierHead(nn.Module):
         Tensor
             Logits of shape (B, num_classes).
         """
+        if self.pool_type != PoolType.NONE and x.dim() not in [2, 3]:
+            raise ValueError(
+                f"{self.__class__.__name__}: Input must be 2D or 3D when pool_type='{self.pool_type}'. "
+                f"Got {x.dim()}D input with shape {list(x.shape)}."
+            )
+
+        if self.pool_type != PoolType.NONE and x.dim() not in [2, 3]:
+            raise ValueError(
+                f"{self.__class__.__name__}: Input must be 2D or 3D when pool_type='{self.pool_type}'. "
+                f"Got {x.dim()}D input with shape {list(x.shape)}."
+            )
+
+        if self.pool_type != PoolType.NONE and x.dim() not in [2, 3]:
+            raise ValueError(
+                f"{self.__class__.__name__}: Input must be 2D or 3D when pool_type='{self.pool_type}'. "
+                f"Got {x.dim()}D input with shape {list(x.shape)}."
+            )
+
         # Handle pooling for sequence inputs
         if x.ndim == 3:  # noqa: PLR2004
             if self.pool_type == PoolType.TOKEN:

--- a/energy_transformer/layers/hopfield.py
+++ b/energy_transformer/layers/hopfield.py
@@ -9,6 +9,7 @@ from .constants import (
     DEFAULT_HOPFIELD_MULTIPLIER,
     DEFAULT_INIT_STD,
 )
+from .validation import validate_positive, validate_tensor_dim
 
 
 class HopfieldNetwork(nn.Module):
@@ -139,7 +140,8 @@ class HopfieldNetwork(nn.Module):
 
         if activation not in ["relu", "softmax"]:
             raise ValueError(
-                f"activation must be 'relu' or 'softmax', got {activation}"
+                f"HopfieldNetwork: activation must be 'relu' or 'softmax'. "
+                f"Got: '{activation}'."
             )
 
         self.kernel = nn.Parameter(
@@ -154,6 +156,7 @@ class HopfieldNetwork(nn.Module):
             self.register_parameter("bias", None)
 
         if activation == "softmax":
+            validate_positive(beta, "HopfieldNetwork", "beta")
             self.beta = nn.Parameter(
                 torch.tensor(beta, device=device, dtype=dtype)
             )
@@ -182,6 +185,8 @@ class HopfieldNetwork(nn.Module):
         torch.Tensor
             Scalar energy value.
         """
+        validate_tensor_dim(g, 3, "HopfieldNetwork", "g")
+
         h = torch.matmul(g, self.kernel)  # shape: [..., N, K]
 
         if self.use_bias:

--- a/energy_transformer/layers/layer_norm.py
+++ b/energy_transformer/layers/layer_norm.py
@@ -149,6 +149,26 @@ class EnergyLayerNorm(nn.Module):
         torch.Tensor
             Normalized tensor of same shape as input.
         """
+        if x.dim() < len(self.normalized_shape):
+            raise ValueError(
+                f"EnergyLayerNorm: Input must have at least {len(self.normalized_shape)} dimensions "
+                f"for normalized_shape={self.normalized_shape}. Got {x.dim()}D input."
+            )
+
+        for i, (actual, expected) in enumerate(
+            zip(
+                x.shape[-len(self.normalized_shape) :],
+                self.normalized_shape,
+                strict=False,
+            )
+        ):
+            if actual != expected:
+                raise ValueError(
+                    f"EnergyLayerNorm: Input shape mismatch at dimension {-len(self.normalized_shape) + i}. "
+                    f"Expected trailing dimensions {self.normalized_shape}, "
+                    f"got {tuple(x.shape[-len(self.normalized_shape) :])}"
+                )
+
         dims = [-(i + 1) for i in range(len(self.normalized_shape))]
 
         if self.enforce_positive_gamma:

--- a/energy_transformer/layers/mlp.py
+++ b/energy_transformer/layers/mlp.py
@@ -78,6 +78,12 @@ class MLP(nn.Module):
         Tensor
             Output tensor of shape (..., out_features).
         """
+        if x.size(-1) != self.fc1.in_features:
+            raise ValueError(
+                f"MLP: Feature dimension mismatch. "
+                f"Expected: {self.fc1.in_features}, got: {x.size(-1)}."
+            )
+
         x = cast(Tensor, self.fc1(x))
         x = cast(Tensor, self.act(x))
         x = cast(Tensor, self.drop(x))

--- a/energy_transformer/layers/validation.py
+++ b/energy_transformer/layers/validation.py
@@ -1,0 +1,90 @@
+"""Input validation utilities for Energy Transformer layers."""
+
+from collections.abc import Sequence
+
+from torch import Tensor
+
+
+def validate_tensor_dim(
+    x: Tensor,
+    expected_dim: int,
+    module_name: str,
+    param_name: str = "input",
+) -> None:
+    """Validate tensor dimensionality."""
+    if x.dim() != expected_dim:
+        raise ValueError(
+            f"{module_name}: {param_name} must be {expected_dim}D tensor. "
+            f"Expected shape: {'[' + ', '.join(['...'] * expected_dim) + ']'}, "
+            f"got shape: {list(x.shape)} ({x.dim()}D)."
+        )
+
+
+def validate_shape_match(
+    x: Tensor,
+    expected_shape: Sequence[int],
+    module_name: str,
+    param_name: str = "input",
+    dims_to_check: Sequence[int] | None = None,
+) -> None:
+    """Validate specific dimensions of tensor shape."""
+    if dims_to_check is None:
+        dims_to_check = range(len(expected_shape))
+
+    for dim_idx in dims_to_check:
+        if dim_idx >= x.dim():
+            raise ValueError(
+                f"{module_name}: {param_name} has insufficient dimensions. "
+                f"Expected at least {dim_idx + 1} dimensions, got {x.dim()}."
+            )
+        if (
+            expected_shape[dim_idx] != -1
+            and x.shape[dim_idx] != expected_shape[dim_idx]
+        ):
+            raise ValueError(
+                f"{module_name}: {param_name} dimension {dim_idx} mismatch. "
+                f"Expected: {expected_shape[dim_idx]}, got: {x.shape[dim_idx]}."
+            )
+
+
+def validate_divisibility(
+    value: int,
+    divisor: int,
+    module_name: str,
+    value_name: str,
+    divisor_name: str,
+) -> None:
+    """Validate that value is divisible by divisor."""
+    if value % divisor != 0:
+        raise ValueError(
+            f"{module_name}: {value_name} must be divisible by {divisor_name}. "
+            f"Got {value_name}={value}, {divisor_name}={divisor}, "
+            f"remainder={value % divisor}."
+        )
+
+
+def validate_positive(
+    value: float,
+    module_name: str,
+    param_name: str,
+) -> None:
+    """Validate that value is positive."""
+    if value <= 0:
+        raise ValueError(
+            f"{module_name}: {param_name} must be positive. "
+            f"Got {param_name}={value}."
+        )
+
+
+def format_shape_error(
+    module_name: str,
+    expected: str,
+    actual: str,
+    context: str = "",
+) -> str:
+    """Format a standardized shape error message."""
+    msg = f"{module_name}: Shape mismatch"
+    if context:
+        msg += f" {context}"
+    msg += f". Expected: {expected}, got: {actual}."
+    return msg

--- a/tests/unit/layers/test_embeddings.py
+++ b/tests/unit/layers/test_embeddings.py
@@ -27,7 +27,9 @@ def test_patch_embedding_output_shape() -> None:
 def test_patch_embedding_raises_for_wrong_size() -> None:
     patch = ConvPatchEmbed(img_size=4, patch_size=2, in_chans=3, embed_dim=8)
     x = torch.randn(1, 3, 5, 4)
-    with pytest.raises(AssertionError):
+    with pytest.raises(
+        ValueError, match="ConvPatchEmbed: Input image size mismatch"
+    ):
         patch(x)
 
 
@@ -123,5 +125,7 @@ def test_patchify_embed_roundtrip() -> None:
 def test_positional_embedding_length_mismatch(batched: bool) -> None:
     pos = PosEmbed2D(num_patches=3, embed_dim=2)
     x = torch.zeros(1, 4, 2) if batched else torch.zeros(4, 2)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(
+        ValueError, match="PosEmbed2D: Sequence length mismatch"
+    ):
         pos(x)

--- a/tests/unit/layers/test_hopfield.py
+++ b/tests/unit/layers/test_hopfield.py
@@ -10,7 +10,7 @@ def test_hopfield_energy_matches_manual() -> None:
     net = HopfieldNetwork(2, hidden_dim=2)
     with torch.no_grad():
         net.kernel.copy_(torch.tensor([[1.0, 0.0], [0.0, 1.0]]))
-    g = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    g = torch.tensor([[1.0, 2.0], [3.0, 4.0]]).unsqueeze(0)
     energy = net(g)
     h = torch.matmul(g, net.kernel)
     expected = -0.5 * (torch.relu(h) ** 2).sum()
@@ -22,7 +22,7 @@ def test_hopfield_softmax_energy_matches_manual() -> None:
     net = HopfieldNetwork(2, hidden_dim=2, activation="softmax", beta=beta)
     with torch.no_grad():
         net.kernel.copy_(torch.tensor([[1.0, 0.0], [0.0, 1.0]]))
-    g = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    g = torch.tensor([[1.0, 2.0], [3.0, 4.0]]).unsqueeze(0)
     energy = net(g)
     h = torch.matmul(g, net.kernel)
     expected = -(1.0 / beta) * torch.logsumexp(beta * h, dim=-1).sum()
@@ -36,7 +36,7 @@ def test_hopfield_default_hidden_dim() -> None:
 
 def test_hopfield_energy_is_scalar() -> None:
     net = HopfieldNetwork(2, hidden_dim=2)
-    g = torch.randn(2, 2)
+    g = torch.randn(1, 2, 2)
     energy = net(g)
     assert energy.shape == torch.Size([])
 
@@ -67,7 +67,7 @@ def test_hopfield_forward_with_batch_dims() -> None:
 
 def test_hopfield_gradients_flow() -> None:
     net = HopfieldNetwork(2, hidden_dim=2)
-    g = torch.randn(3, 2, requires_grad=True)
+    g = torch.randn(1, 3, 2, requires_grad=True)
     energy = net(g)
     energy.backward()
     assert g.grad is not None
@@ -78,7 +78,7 @@ def test_hopfield_zero_weights_energy_zero() -> None:
     net = HopfieldNetwork(3, hidden_dim=2)
     with torch.no_grad():
         net.kernel.zero_()
-    g = torch.randn(5, 3)
+    g = torch.randn(1, 5, 3)
     energy = net(g)
     assert torch.allclose(energy, torch.tensor(0.0))
 
@@ -87,7 +87,7 @@ def test_hopfield_negative_activations() -> None:
     net = HopfieldNetwork(2, hidden_dim=2)
     with torch.no_grad():
         net.kernel.copy_(torch.tensor([[1.0, -1.0], [0.5, 0.5]]))
-    g = torch.tensor([[1.0, 2.0], [-1.0, 1.0]])
+    g = torch.tensor([[1.0, 2.0], [-1.0, 1.0]]).unsqueeze(0)
     energy = net(g)
     h = torch.matmul(g, net.kernel)
     expected = -0.5 * (torch.relu(h) ** 2).sum()
@@ -105,7 +105,7 @@ def test_hopfield_compute_grad_relu() -> None:
     net = HopfieldNetwork(2, hidden_dim=2)
     with torch.no_grad():
         net.kernel.copy_(torch.tensor([[1.0, 0.0], [0.0, 1.0]]))
-    g = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    g = torch.tensor([[1.0, 2.0], [3.0, 4.0]]).unsqueeze(0)
     grad = net.compute_grad(g)
     h = torch.matmul(g, net.kernel)
     expected = -torch.matmul(torch.relu(h), net.kernel.t())
@@ -117,7 +117,7 @@ def test_hopfield_compute_grad_softmax() -> None:
     net = HopfieldNetwork(2, hidden_dim=2, activation="softmax", beta=beta)
     with torch.no_grad():
         net.kernel.copy_(torch.tensor([[1.0, 0.0], [0.0, 1.0]]))
-    g = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    g = torch.tensor([[1.0, 2.0], [3.0, 4.0]]).unsqueeze(0)
     grad = net.compute_grad(g)
     h = torch.matmul(g, net.kernel)
     expected = -torch.matmul(torch.softmax(beta * h, dim=-1), net.kernel.t())


### PR DESCRIPTION
## Summary
- centralize validation in `validation.py`
- use validation utilities in layers
- improve error messages for embedding layers
- validate inputs in attention, hopfield, layer norm, heads, and mlp
- update unit tests for new validation behavior

## Testing
- `ruff check energy_transformer/layers --fix`
- `ruff format energy_transformer/layers`
- `mypy energy_transformer/layers`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841eb5d9780832b813a7fabaf463520