### PR TITLE
[models] add simplicial transformer

### DIFF
--- a/energy_transformer/layers/__init__.py
+++ b/energy_transformer/layers/__init__.py
@@ -43,6 +43,7 @@ from .heads import (
 from .hopfield import HopfieldNetwork
 from .layer_norm import EnergyLayerNorm
 from .mlp import MLP
+from .simplicial import SHNReLU, SHNSoftmax, SimplicialHopfieldNetwork
 
 __all__ = [
     "MLP",
@@ -57,4 +58,7 @@ __all__ = [
     "PatchifyEmbed",
     "PosEmbed2D",
     "ReLUMLPClassifierHead",
+    "SHNReLU",
+    "SHNSoftmax",
+    "SimplicialHopfieldNetwork",
 ]

--- a/energy_transformer/layers/hopfield.py
+++ b/energy_transformer/layers/hopfield.py
@@ -14,10 +14,31 @@ from .validation import validate_positive, validate_tensor_dim
 
 
 class HopfieldNetwork(nn.Module):
-    r"""Energy-based Hopfield Network module.
+    r"""Hopfield Network for associative memory.
 
-    Implements the Hopfield Network component of Energy Transformer blocks,
-    which ensures token representations are consistent with learned memory patterns.
+    Mathematical Foundation
+    -----------------------
+    The Hopfield Network ensures token representations are consistent with
+    learned memory patterns. The energy function is:
+
+    .. math::
+        E^{HN} = -\sum_{B=1}^{N} \sum_{\mu=1}^{K} G\left(\sum_{j=1}^{D} \xi_{\mu j} g_{jB}\right)
+
+    where:
+    - \(\xi_{\mu j}\) are learnable memory patterns
+    - \(G(\cdot)\) is the integral of the activation function ``r`` so that
+      ``G'(\cdot) = r(\cdot)``
+
+    For different activation functions:
+    - Classical (ReLU): ``r(x) = max(0, x)`` with slowly growing energy
+    - Modern (softmax): ``r(x) = softmax(x)`` with sharply peaked basins
+
+    The gradient contribution is:
+
+    .. math::
+        -\frac{\partial E^{HN}}{\partial g_{iA}} = \sum_{\mu=1}^{K} \xi_{\mu i} r\left(\sum_{j=1}^{D} \xi_{\mu j} g_{jA}\right)
+
+    This is applied to each token individually (no inter-token mixing).
 
     Parameters
     ----------

--- a/energy_transformer/layers/layer_norm.py
+++ b/energy_transformer/layers/layer_norm.py
@@ -17,8 +17,27 @@ from .types import Device, Dtype
 class EnergyLayerNorm(nn.Module):
     r"""Energy-based Layer Normalization.
 
-    Implements layer normalization as described in Energy Transformer theory,
-    where the operation emerges as the gradient of an energy function.
+    Mathematical Foundation
+    -----------------------
+    Each token is represented by a vector ``x \in \mathbb{R}^D``. The
+    layer-normalized representation is:
+
+    .. math::
+        g_i = \gamma \frac{x_i - \bar{x}}{\sqrt{\frac{1}{D}\sum_j(x_j - \bar{x})^2 + \varepsilon}} + \delta_i
+
+    where :math:`\bar{x} = \frac{1}{D}\sum_{k=1}^D x_k`.
+
+    Importantly, this operation can be viewed as the partial derivative of the
+    Lagrangian:
+
+    .. math::
+        L = D\gamma\sqrt{\frac{1}{D}\sum_j(x_j - \bar{x})^2 + \varepsilon} + \sum_j \delta_j x_j
+
+    such that :math:`g_i = \frac{\partial L}{\partial x_i}`. This property is
+    crucial for proving energy decrease in the Energy Transformer dynamics. The
+    symmetric part of the Hessian
+    :math:`M_{ij} = \frac{\partial^2 L}{\partial x_i \partial x_j}` is positive
+    semi-definite, which guarantees :math:`\frac{dE}{dt} \leq 0`.
 
     Parameters
     ----------

--- a/energy_transformer/layers/simplicial.py
+++ b/energy_transformer/layers/simplicial.py
@@ -1,0 +1,279 @@
+"""Simplicial Hopfield Network implementation.
+
+This module implements higher-order Hopfield networks operating on simplicial
+complexes, generalizing the standard Hopfield network to k-way interactions
+between tokens as described in "Simplicial Hopfield Networks" (2023).
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F  # noqa: N812
+from torch import Tensor, nn
+
+from .constants import (
+    DEFAULT_HOPFIELD_BETA,
+    DEFAULT_HOPFIELD_MULTIPLIER,
+    DEFAULT_INIT_STD,
+)
+from .types import ActivationType, Device, Dtype, EmbedDim, HiddenDim
+from .validation import validate_positive, validate_tensor_dim
+
+__all__ = ["SHNReLU", "SHNSoftmax", "SimplicialHopfieldNetwork"]
+
+
+class SimplicialHopfieldNetwork(nn.Module):
+    r"""Energy-based Simplicial Hopfield Network module.
+
+    Mathematical Foundation
+    -----------------------
+    The Simplicial Hopfield Network extends memory storage to ``k``-way
+    interactions between tokens. The energy function is:
+
+    .. math::
+        E^{SHN} = -\frac{1}{k} \sum_{B=1}^{N} \sum_{\mu=1}^{K} \left(\sum_{v=1}^{k} r\left(\sum_{j=1}^{D} \xi_{v,\mu j} g_{jB}\right)\right)^2
+
+    where ``k`` is the order of the simplex, ``\xi_v`` are memory patterns for
+    each vertex, and ``r`` is the activation function per vertex.
+
+    The gradient is:
+
+    .. math::
+        -\frac{\partial E^{SHN}}{\partial g_{iA}} = \frac{1}{k} \sum_{v=1}^{k} \sum_{\mu=1}^{K} \xi_{v,\mu i} \left(\sum_{u=1}^{k} r_{\mu u}\right) r'_{\mu v}
+
+    For softmax activation the expression simplifies to
+
+    .. math::
+        -\frac{\partial E^{SHN}}{\partial g_{iA}} = \frac{1}{k} \sum_{v=1}^{k} \xi_v^T \text{softmax}(\beta h_v)
+    """
+
+    activation: ActivationType
+    beta: nn.Parameter | None
+
+    def __init__(
+        self,
+        embed_dim: EmbedDim,
+        hidden_dim: HiddenDim | None = None,
+        hidden_ratio: float = DEFAULT_HOPFIELD_MULTIPLIER,
+        order: int = 3,
+        activation: ActivationType = "relu",
+        beta: float = DEFAULT_HOPFIELD_BETA,
+        bias: bool = False,
+        init_std: float = DEFAULT_INIT_STD,
+        device: Device = None,
+        dtype: Dtype = None,
+    ) -> None:
+        super().__init__()
+
+        factory_kwargs = {"device": device, "dtype": dtype}
+
+        if order < 2:  # noqa: PLR2004
+            raise ValueError(
+                f"SimplicialHopfieldNetwork: order must be >= 2. Got: {order}. "
+                "Use HopfieldNetwork for order=2."
+            )
+
+        self.embed_dim = embed_dim
+        self.hidden_dim = hidden_dim or int(embed_dim * hidden_ratio)
+        self.order = order
+        self.activation = activation
+        self.use_bias = bias
+        self.init_std = init_std
+
+        if activation not in ["relu", "softmax"]:
+            raise ValueError(
+                "SimplicialHopfieldNetwork: activation must be 'relu' or 'softmax'. "
+                f"Got: '{activation}'."
+            )
+
+        self.kernel = nn.Parameter(
+            torch.empty((order, embed_dim, self.hidden_dim), **factory_kwargs)  # type: ignore[arg-type]
+        )
+
+        if self.use_bias:
+            self.bias = nn.Parameter(
+                torch.zeros((order, 1, 1, self.hidden_dim), **factory_kwargs)  # type: ignore[arg-type]
+            )
+        else:
+            self.register_parameter("bias", None)
+
+        if activation == "softmax":
+            validate_positive(beta, "SimplicialHopfieldNetwork", "beta")
+            self.beta = nn.Parameter(torch.tensor(beta, **factory_kwargs))  # type: ignore[arg-type]
+        else:
+            self.register_buffer("beta", None)
+
+        self._reset_parameters()
+
+    def _reset_parameters(self) -> None:
+        nn.init.normal_(self.kernel, std=self.init_std)
+        # Bias initialized to zeros; keep beta as provided
+
+    def _project(self, g: Tensor) -> Tensor:
+        kernel = self.kernel.to(g.dtype)
+        return torch.einsum("...nd,vdk->...vnk", g, kernel)
+
+    def forward(self, g: Tensor) -> Tensor:
+        """Compute energy for input tokens."""
+        validate_tensor_dim(g, 3, "SimplicialHopfieldNetwork", "g")
+
+        h = self._project(g)
+        if self.use_bias:
+            bias = self.bias.to(g.dtype).view(1, self.order, 1, self.hidden_dim)
+            h = h + bias
+
+        if self.activation == "relu":
+            a_v = F.relu(h, inplace=True)
+            sum_a = a_v.sum(dim=-3)
+            energy = -0.5 / self.order * sum_a.pow(2).sum()
+        else:
+            assert self.beta is not None
+            h = h * self.beta
+            lse = torch.logsumexp(h, dim=-1)
+            energy = -(1.0 / (self.order * self.beta)) * lse.sum()
+        return energy
+
+    def compute_grad(self, g: Tensor) -> Tensor:
+        """Return gradient of energy with respect to input."""
+        h = self._project(g)
+        if self.use_bias:
+            bias = self.bias.to(g.dtype).view(1, self.order, 1, self.hidden_dim)
+            h = h + bias
+
+        if self.activation == "relu":
+            a_v = F.relu(h)
+            sum_a = a_v.sum(dim=-3, keepdim=True)
+            indicator = (h > 0).type_as(h)
+            factor = (sum_a * indicator) / self.order
+            grad = -torch.einsum(
+                "vdk,...vnk->...nd", self.kernel.to(g.dtype), factor
+            )
+        else:
+            assert self.beta is not None
+            h = h * self.beta
+            a_v = F.softmax(h, dim=-1)
+            grad = (
+                -torch.einsum("vdk,...vnk->...nd", self.kernel.to(g.dtype), a_v)
+                / self.order
+            )
+        return grad
+
+    @property
+    def memory_dim(self) -> int:
+        """Number of memory patterns stored."""
+        return self.hidden_dim
+
+    @property
+    def input_dim(self) -> int:
+        """Input feature dimension."""
+        return self.embed_dim
+
+    @property
+    def simplex_order(self) -> int:
+        """Order of simplicial interactions."""
+        return self.order
+
+    @property
+    def activation_type(self) -> str:
+        """Activation function type."""
+        return self.activation
+
+    @property
+    def is_classical(self) -> bool:
+        """Whether activation is ReLU."""
+        return self.activation == "relu"
+
+    @property
+    def is_modern(self) -> bool:
+        """Whether activation is softmax."""
+        return self.activation == "softmax"
+
+    @property
+    def temperature(self) -> float | None:
+        """Temperature parameter for softmax."""
+        if self.activation == "softmax":
+            assert self.beta is not None
+            return self.beta.item()
+        return None
+
+    @property
+    def total_params(self) -> int:
+        """Total number of learnable parameters."""
+        param_count = self.order * self.embed_dim * self.hidden_dim
+        if self.use_bias:
+            param_count += self.order * self.hidden_dim
+        if self.activation == "softmax" and isinstance(self.beta, nn.Parameter):
+            param_count += 1
+        return param_count
+
+    @property
+    def device(self) -> torch.device:
+        """Device of module parameters."""
+        return self.kernel.device
+
+    def extra_repr(self) -> str:
+        """Return string representation for module printing."""
+        parts = [
+            f"embed_dim={self.embed_dim}",
+            f"hidden_dim={self.hidden_dim}",
+            f"order={self.order}",
+            f"activation='{self.activation}'",
+        ]
+        if self.activation == "softmax":
+            assert self.beta is not None
+            parts.append(f"beta={self.beta.item():.3f}")
+        if self.use_bias:
+            parts.append("bias=True")
+        return ", ".join(parts)
+
+
+class SHNReLU(SimplicialHopfieldNetwork):
+    """Classical Simplicial Hopfield Network with ReLU activation."""
+
+    def __init__(
+        self,
+        embed_dim: int,
+        hidden_ratio: float = DEFAULT_HOPFIELD_MULTIPLIER,
+        order: int = 3,
+        bias: bool = False,
+        init_std: float = DEFAULT_INIT_STD,
+        device: torch.device | None = None,
+        dtype: torch.dtype | None = None,
+    ) -> None:
+        super().__init__(
+            embed_dim=embed_dim,
+            hidden_ratio=hidden_ratio,
+            order=order,
+            activation="relu",
+            bias=bias,
+            init_std=init_std,
+            device=device,
+            dtype=dtype,
+        )
+
+
+class SHNSoftmax(SimplicialHopfieldNetwork):
+    """Modern Simplicial Hopfield Network with softmax activation."""
+
+    def __init__(
+        self,
+        embed_dim: int,
+        hidden_ratio: float = DEFAULT_HOPFIELD_MULTIPLIER,
+        order: int = 3,
+        beta: float = DEFAULT_HOPFIELD_BETA,
+        bias: bool = False,
+        init_std: float = DEFAULT_INIT_STD,
+        device: torch.device | None = None,
+        dtype: torch.dtype | None = None,
+    ) -> None:
+        super().__init__(
+            embed_dim=embed_dim,
+            hidden_ratio=hidden_ratio,
+            order=order,
+            activation="softmax",
+            beta=beta,
+            bias=bias,
+            init_std=init_std,
+            device=device,
+            dtype=dtype,
+        )

--- a/energy_transformer/models/vision/__init__.py
+++ b/energy_transformer/models/vision/__init__.py
@@ -49,6 +49,20 @@ from .viet import (
     viet_tiny_cifar,
 )
 
+# Vision Simplicial Energy Transformer
+from .viset import (
+    VisionSimplicialTransformer,
+    viset_2l_cifar,
+    viset_4l_cifar,
+    viset_6l_cifar,
+    viset_base,
+    viset_large,
+    viset_small,
+    viset_small_cifar,
+    viset_tiny,
+    viset_tiny_cifar,
+)
+
 # Standard Vision Transformer (baseline)
 from .vit import (
     VisionTransformer,
@@ -64,11 +78,9 @@ from .vit import (
 
 __all__ = [
     "REALISER_REGISTRY",
-    # Core models and registry
     "EnergyTransformer",
-    # Vision Energy Transformer (ViET)
     "VisionEnergyTransformer",
-    # Vision Transformer (ViT) - Baseline
+    "VisionSimplicialTransformer",
     "VisionTransformer",
     "viet_2l_cifar",
     "viet_4l_cifar",
@@ -79,6 +91,15 @@ __all__ = [
     "viet_small_cifar",
     "viet_tiny",
     "viet_tiny_cifar",
+    "viset_2l_cifar",
+    "viset_4l_cifar",
+    "viset_6l_cifar",
+    "viset_base",
+    "viset_large",
+    "viset_small",
+    "viset_small_cifar",
+    "viset_tiny",
+    "viset_tiny_cifar",
     "vit_base",
     "vit_large",
     "vit_small",

--- a/energy_transformer/models/vision/viset.py
+++ b/energy_transformer/models/vision/viset.py
@@ -1,0 +1,354 @@
+"""Vision Simplicial Energy Transformer (ViSET) implementation."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import torch
+from torch import Tensor, nn
+
+from energy_transformer.layers.attention import MultiheadEnergyAttention
+from energy_transformer.layers.embeddings import ConvPatchEmbed, PosEmbed2D
+from energy_transformer.layers.heads import ClassifierHead
+from energy_transformer.layers.layer_norm import EnergyLayerNorm
+from energy_transformer.layers.simplicial import SimplicialHopfieldNetwork
+from energy_transformer.layers.types import ActivationType
+from energy_transformer.models.base import EnergyTransformer
+from energy_transformer.utils.optimizers import SGD
+
+
+class VisionSimplicialTransformer(nn.Module):
+    """Vision Simplicial Energy Transformer (ViSET)."""
+
+    def __init__(
+        self,
+        img_size: int,
+        patch_size: int,
+        in_chans: int,
+        num_classes: int,
+        embed_dim: int,
+        depth: int,
+        num_heads: int,
+        _head_dim: int,
+        hopfield_hidden_dim: int,
+        et_steps: int,
+        et_alpha: float,
+        order: int = 3,
+        drop_rate: float = 0.0,
+        _representation_size: int | None = None,
+        hopfield_activation: str = "relu",
+        hopfield_beta: float = 0.01,
+    ) -> None:
+        super().__init__()
+
+        self.img_size = img_size
+        self.patch_size = patch_size
+        self.embed_dim = embed_dim
+        self.depth = depth
+        self.num_classes = num_classes
+        self.order = order
+
+        self.patch_embed = ConvPatchEmbed(
+            img_size=img_size,
+            patch_size=patch_size,
+            in_chans=in_chans,
+            embed_dim=embed_dim,
+        )
+        num_patches = self.patch_embed.num_patches
+
+        self.cls_token = nn.Parameter(torch.zeros(1, 1, embed_dim))
+        self.pos_embed = PosEmbed2D(
+            num_patches=num_patches, embed_dim=embed_dim, cls_token=True
+        )
+        self.pos_drop = nn.Dropout(p=drop_rate)
+
+        self.et_blocks = nn.ModuleList(
+            [
+                EnergyTransformer(
+                    layer_norm=EnergyLayerNorm(embed_dim),
+                    attention=MultiheadEnergyAttention(
+                        embed_dim=embed_dim, num_heads=num_heads
+                    ),
+                    hopfield=SimplicialHopfieldNetwork(
+                        embed_dim,
+                        hidden_dim=hopfield_hidden_dim,
+                        order=order,
+                        activation=cast(ActivationType, hopfield_activation),
+                        beta=hopfield_beta,
+                    ),
+                    steps=et_steps,
+                    optimizer=SGD(alpha=et_alpha),
+                )
+                for _ in range(depth)
+            ]
+        )
+
+        self.norm = EnergyLayerNorm(embed_dim)
+        self.head = ClassifierHead(
+            in_features=embed_dim,
+            num_classes=num_classes,
+            pool_type="token",
+            drop_rate=drop_rate,
+        )
+
+        nn.init.trunc_normal_(self.cls_token, std=0.02)
+        nn.init.trunc_normal_(self.pos_embed.pos_embed, std=0.02)
+
+    def _process_et_blocks(
+        self,
+        x: Tensor,
+        return_energy_info: bool,
+        _et_kwargs: dict[str, Any],
+    ) -> tuple[Tensor, dict[str, Any]]:
+        energy_info: dict[str, Any] = {}
+        if not return_energy_info:
+            for et_block in self.et_blocks:
+                x = et_block(x)
+            return x, energy_info
+
+        block_energies: list[float] = []
+        block_trajectories: list[Any] = []
+        for et_block in self.et_blocks:
+            if hasattr(et_block, "_compute_energy"):
+                x = et_block(x)
+                block_energies.append(et_block._compute_energy(x).item())
+            else:
+                result = et_block(x, track="both")
+                if hasattr(result, "tokens"):
+                    x = result.tokens
+                    if result.final_energy is not None:
+                        block_energies.append(result.final_energy.item())
+                    if result.trajectory is not None:
+                        block_trajectories.append(
+                            result.trajectory.cpu().numpy()
+                        )
+                else:
+                    x = result
+        total_energy = sum(block_energies) if block_energies else None
+        energy_info = {
+            "block_energies": block_energies,
+            "block_trajectories": block_trajectories,
+            "total_energy": total_energy,
+        }
+        return x, energy_info
+
+    def forward(
+        self,
+        x: Tensor,
+        return_features: bool = False,
+        return_energy_info: bool = False,
+        et_kwargs: dict[str, Any] | None = None,
+    ) -> Tensor | dict[str, Any]:
+        """Forward pass of the model."""
+        et_kwargs = et_kwargs or {}
+
+        if x.shape[-2:] != (self.img_size, self.img_size):
+            raise ValueError(
+                f"Input size {x.shape[-2:]} doesn't match model size ({self.img_size}, {self.img_size})"
+            )
+
+        x = self.patch_embed(x)
+        cls_tokens = self.cls_token.expand(x.size(0), -1, -1)
+        x = torch.cat([cls_tokens, x], dim=1)
+        x = self.pos_embed(x)
+        x = self.pos_drop(x)
+
+        x, energy_info = self._process_et_blocks(
+            x, return_energy_info, et_kwargs
+        )
+
+        x = self.norm(x)
+
+        if return_features:
+            assert isinstance(x, Tensor)
+            features = x[:, 0]
+            if return_energy_info:
+                return {"features": features, "energy_info": energy_info}
+            return features
+        logits: Tensor = self.head(x)
+        if return_energy_info:
+            return {"logits": logits, "energy_info": energy_info}
+        return logits
+
+
+def viset_tiny(**kwargs: Any) -> VisionSimplicialTransformer:
+    """ViSET-Tiny configuration."""
+    config: dict[str, Any] = {
+        "embed_dim": 192,
+        "depth": 12,
+        "num_heads": 3,
+        "_head_dim": 64,
+        "hopfield_hidden_dim": 768,
+        "et_steps": 4,
+        "et_alpha": 0.125,
+        "order": 3,
+        "in_chans": 3,
+    }
+    config.update(kwargs)
+    return VisionSimplicialTransformer(**config)
+
+
+def viset_small(**kwargs: Any) -> VisionSimplicialTransformer:
+    """ViSET-Small configuration."""
+    config: dict[str, Any] = {
+        "embed_dim": 384,
+        "depth": 12,
+        "num_heads": 6,
+        "_head_dim": 64,
+        "hopfield_hidden_dim": 1536,
+        "et_steps": 4,
+        "et_alpha": 0.125,
+        "order": 3,
+        "in_chans": 3,
+    }
+    config.update(kwargs)
+    return VisionSimplicialTransformer(**config)
+
+
+def viset_base(**kwargs: Any) -> VisionSimplicialTransformer:
+    """ViSET-Base configuration."""
+    config: dict[str, Any] = {
+        "embed_dim": 768,
+        "depth": 12,
+        "num_heads": 12,
+        "_head_dim": 64,
+        "hopfield_hidden_dim": 3072,
+        "et_steps": 4,
+        "et_alpha": 0.125,
+        "order": 3,
+        "in_chans": 3,
+    }
+    config.update(kwargs)
+    return VisionSimplicialTransformer(**config)
+
+
+def viset_large(**kwargs: Any) -> VisionSimplicialTransformer:
+    """ViSET-Large configuration."""
+    config: dict[str, Any] = {
+        "embed_dim": 1024,
+        "depth": 24,
+        "num_heads": 16,
+        "_head_dim": 64,
+        "hopfield_hidden_dim": 4096,
+        "et_steps": 4,
+        "et_alpha": 0.125,
+        "order": 3,
+        "in_chans": 3,
+    }
+    config.update(kwargs)
+    return VisionSimplicialTransformer(**config)
+
+
+def viset_tiny_cifar(
+    num_classes: int = 100, **kwargs: Any
+) -> VisionSimplicialTransformer:
+    """ViSET-Tiny for CIFAR datasets."""
+    config: dict[str, Any] = {
+        "img_size": 32,
+        "patch_size": 4,
+        "in_chans": 3,
+        "num_classes": num_classes,
+        "embed_dim": 192,
+        "depth": 12,
+        "num_heads": 3,
+        "_head_dim": 64,
+        "hopfield_hidden_dim": 768,
+        "et_steps": 4,
+        "et_alpha": 0.125,
+        "order": 3,
+        "drop_rate": 0.1,
+    }
+    config.update(kwargs)
+    return VisionSimplicialTransformer(**config)
+
+
+def viset_small_cifar(
+    num_classes: int = 100, **kwargs: Any
+) -> VisionSimplicialTransformer:
+    """ViSET-Small for CIFAR datasets."""
+    config: dict[str, Any] = {
+        "img_size": 32,
+        "patch_size": 4,
+        "in_chans": 3,
+        "num_classes": num_classes,
+        "embed_dim": 384,
+        "depth": 12,
+        "num_heads": 6,
+        "_head_dim": 64,
+        "hopfield_hidden_dim": 1536,
+        "et_steps": 4,
+        "et_alpha": 0.125,
+        "order": 3,
+        "drop_rate": 0.1,
+    }
+    config.update(kwargs)
+    return VisionSimplicialTransformer(**config)
+
+
+def viset_2l_cifar(
+    num_classes: int = 100, **kwargs: Any
+) -> VisionSimplicialTransformer:
+    """2-layer ViSET for CIFAR datasets."""
+    config: dict[str, Any] = {
+        "img_size": 32,
+        "patch_size": 4,
+        "in_chans": 3,
+        "num_classes": num_classes,
+        "embed_dim": 192,
+        "depth": 2,
+        "num_heads": 8,
+        "_head_dim": 64,
+        "hopfield_hidden_dim": 576,
+        "et_steps": 6,
+        "et_alpha": 10.0,
+        "order": 3,
+        "drop_rate": 0.1,
+    }
+    config.update(kwargs)
+    return VisionSimplicialTransformer(**config)
+
+
+def viset_4l_cifar(
+    num_classes: int = 100, **kwargs: Any
+) -> VisionSimplicialTransformer:
+    """4-layer ViSET for CIFAR datasets."""
+    config: dict[str, Any] = {
+        "img_size": 32,
+        "patch_size": 4,
+        "in_chans": 3,
+        "num_classes": num_classes,
+        "embed_dim": 192,
+        "depth": 4,
+        "num_heads": 8,
+        "_head_dim": 64,
+        "hopfield_hidden_dim": 576,
+        "et_steps": 5,
+        "et_alpha": 5.0,
+        "order": 3,
+        "drop_rate": 0.1,
+    }
+    config.update(kwargs)
+    return VisionSimplicialTransformer(**config)
+
+
+def viset_6l_cifar(
+    num_classes: int = 100, **kwargs: Any
+) -> VisionSimplicialTransformer:
+    """6-layer ViSET for CIFAR datasets."""
+    config: dict[str, Any] = {
+        "img_size": 32,
+        "patch_size": 4,
+        "in_chans": 3,
+        "num_classes": num_classes,
+        "embed_dim": 192,
+        "depth": 6,
+        "num_heads": 8,
+        "_head_dim": 64,
+        "hopfield_hidden_dim": 576,
+        "et_steps": 4,
+        "et_alpha": 2.5,
+        "order": 3,
+        "drop_rate": 0.1,
+    }
+    config.update(kwargs)
+    return VisionSimplicialTransformer(**config)

--- a/tests/unit/layers/test_simplicial.py
+++ b/tests/unit/layers/test_simplicial.py
@@ -1,0 +1,260 @@
+"""Unit tests for Simplicial Hopfield Networks."""
+
+import pytest
+import torch
+
+from energy_transformer.layers.simplicial import (
+    SHNReLU,
+    SHNSoftmax,
+    SimplicialHopfieldNetwork,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_simplicial_hopfield_relu_energy_matches_manual() -> None:
+    """Test that ReLU energy computation matches manual calculation."""
+    net = SimplicialHopfieldNetwork(2, hidden_dim=2, order=3, activation="relu")
+    with torch.no_grad():
+        net.kernel[0].copy_(torch.tensor([[1.0, 0.0], [0.0, 1.0]]))
+        net.kernel[1].copy_(torch.tensor([[1.0, 0.0], [0.0, 1.0]]))
+        net.kernel[2].copy_(torch.tensor([[1.0, 0.0], [0.0, 1.0]]))
+
+    g = torch.tensor([[1.0, 2.0], [3.0, 4.0]]).unsqueeze(0)
+    energy = net(g)
+
+    h = torch.einsum("...nd,vdk->...vnk", g, net.kernel)
+    a_v = torch.relu(h)
+    sum_a = a_v.sum(dim=1)
+    expected = -0.5 / 3 * (sum_a**2).sum()
+
+    assert torch.allclose(energy, expected, atol=1e-6)
+
+
+def test_simplicial_hopfield_softmax_energy_matches_manual() -> None:
+    """Test that softmax energy computation matches manual calculation."""
+    beta = 0.5
+    net = SimplicialHopfieldNetwork(
+        2, hidden_dim=2, order=3, activation="softmax", beta=beta
+    )
+    with torch.no_grad():
+        net.kernel[0].copy_(torch.tensor([[1.0, 0.0], [0.0, 1.0]]))
+        net.kernel[1].copy_(torch.tensor([[0.5, 0.5], [0.5, 0.5]]))
+        net.kernel[2].copy_(torch.tensor([[1.0, 0.0], [0.0, 1.0]]))
+
+    g = torch.tensor([[1.0, 2.0], [3.0, 4.0]]).unsqueeze(0)
+    energy = net(g)
+
+    h = torch.einsum("...nd,vdk->...vnk", g, net.kernel)
+    lse = torch.logsumexp(beta * h, dim=-1)
+    expected = -(1.0 / (3 * beta)) * lse.sum()
+
+    assert torch.allclose(energy, expected, atol=1e-6)
+
+
+def test_simplicial_hopfield_order_validation() -> None:
+    """Test that order < 2 raises ValueError."""
+    with pytest.raises(ValueError, match="order must be >= 2"):
+        SimplicialHopfieldNetwork(2, order=1)
+
+
+def test_simplicial_hopfield_invalid_activation() -> None:
+    """Test that invalid activation raises ValueError."""
+    with pytest.raises(ValueError, match="activation must be"):
+        SimplicialHopfieldNetwork(2, activation="tanh")
+
+
+def test_simplicial_hopfield_default_hidden_dim() -> None:
+    """Test default hidden dimension calculation."""
+    net = SimplicialHopfieldNetwork(3, hidden_dim=None, hidden_ratio=2.5)
+    assert net.hidden_dim == int(3 * 2.5)
+
+
+def test_simplicial_hopfield_energy_is_scalar() -> None:
+    """Test that energy output is a scalar."""
+    net = SimplicialHopfieldNetwork(2, hidden_dim=3, order=4)
+    g = torch.randn(2, 5, 2)
+    energy = net(g)
+    assert energy.shape == torch.Size([])
+
+
+def test_simplicial_hopfield_gradients_flow() -> None:
+    """Test that gradients flow through the network."""
+    net = SimplicialHopfieldNetwork(2, hidden_dim=2, order=3)
+    g = torch.randn(1, 3, 2, requires_grad=True)
+    energy = net(g)
+    energy.backward()
+    assert g.grad is not None
+    assert net.kernel.grad is not None
+
+
+def test_simplicial_hopfield_compute_grad_relu() -> None:
+    """Test gradient computation for ReLU activation."""
+    net = SimplicialHopfieldNetwork(2, hidden_dim=2, order=3, activation="relu")
+    with torch.no_grad():
+        net.kernel.fill_(1.0)
+
+    g = torch.tensor([[1.0, 2.0], [3.0, 4.0]]).unsqueeze(0)
+    grad = net.compute_grad(g)
+    assert grad.shape == g.shape
+
+    g_auto = g.clone().requires_grad_(True)
+    energy = net(g_auto)
+    energy.backward()
+    assert torch.allclose(grad, g_auto.grad, atol=1e-6)
+
+
+def test_simplicial_hopfield_compute_grad_softmax() -> None:
+    """Test gradient computation for softmax activation."""
+    beta = 0.2
+    net = SimplicialHopfieldNetwork(
+        2, hidden_dim=2, order=3, activation="softmax", beta=beta
+    )
+    with torch.no_grad():
+        net.kernel.fill_(0.5)
+
+    g = torch.tensor([[1.0, 2.0], [3.0, 4.0]]).unsqueeze(0)
+    grad = net.compute_grad(g)
+    assert grad.shape == g.shape
+
+    g_auto = g.clone().requires_grad_(True)
+    energy = net(g_auto)
+    energy.backward()
+    assert torch.allclose(grad, g_auto.grad, atol=1e-6)
+
+
+def test_simplicial_hopfield_with_bias() -> None:
+    """Test SimplicalHopfieldNetwork with bias terms."""
+    net = SimplicialHopfieldNetwork(
+        2, hidden_dim=3, order=3, bias=True, activation="relu"
+    )
+    assert net.bias is not None
+    assert net.bias.shape == (3, 1, 1, 3)
+
+    g = torch.randn(2, 4, 2)
+    energy = net(g)
+    assert torch.isfinite(energy)
+
+
+def test_simplicial_hopfield_beta_preserved_after_reset() -> None:
+    """Test that beta value is preserved after parameter reset."""
+    net = SimplicialHopfieldNetwork(3, order=3, activation="softmax", beta=0.5)
+    before = net.beta.clone()
+    net._reset_parameters()
+    assert torch.allclose(net.beta, before)
+
+
+def test_simplicial_hopfield_properties() -> None:
+    """Test network properties."""
+    net = SimplicialHopfieldNetwork(
+        4, hidden_dim=6, order=4, activation="softmax", beta=0.2, bias=True
+    )
+    assert net.memory_dim == 6
+    assert net.input_dim == 4
+    assert net.simplex_order == 4
+    assert net.activation_type == "softmax"
+    assert not net.is_classical
+    assert net.is_modern
+    assert net.temperature == pytest.approx(0.2)
+    expected_params = 4 * 4 * 6 + 4 * 6 + 1
+    assert net.total_params == expected_params
+    assert isinstance(net.device, torch.device)
+
+
+def test_simplicial_hopfield_extra_repr() -> None:
+    """Test string representation."""
+    net = SimplicialHopfieldNetwork(
+        2, hidden_dim=4, order=3, activation="softmax", beta=0.1, bias=True
+    )
+    rep = net.extra_repr()
+    assert "embed_dim=2" in rep
+    assert "hidden_dim=4" in rep
+    assert "order=3" in rep
+    assert "activation='softmax'" in rep
+    assert "beta=0.100" in rep
+    assert "bias=True" in rep
+
+
+def test_simplicial_hopfield_different_orders() -> None:
+    """Test network with different simplicial orders."""
+    for order in [2, 3, 4, 5]:
+        net = SimplicialHopfieldNetwork(3, order=order)
+        g = torch.randn(2, 4, 3)
+        energy = net(g)
+        assert torch.isfinite(energy)
+        assert net.kernel.shape == (order, 3, net.hidden_dim)
+
+
+def test_simplicial_hopfield_numerical_stability() -> None:
+    """Test numerical stability with extreme values."""
+    net = SimplicialHopfieldNetwork(2, order=3, activation="softmax", beta=0.1)
+
+    g_small = torch.full((1, 3, 2), 1e-8)
+    energy_small = net(g_small)
+    assert torch.isfinite(energy_small)
+
+    g_large = torch.full((1, 3, 2), 100.0)
+    energy_large = net(g_large)
+    assert torch.isfinite(energy_large)
+
+
+def test_shn_relu_factory() -> None:
+    """Test SHNReLU factory class."""
+    net = SHNReLU(4, order=3, hidden_ratio=2.0)
+    assert net.activation == "relu"
+    assert net.order == 3
+    assert net.hidden_dim == 8
+    assert net.beta is None
+
+    g = torch.randn(2, 5, 4)
+    energy = net(g)
+    assert torch.isfinite(energy)
+
+
+def test_shn_softmax_factory() -> None:
+    """Test SHNSoftmax factory class."""
+    net = SHNSoftmax(4, order=4, hidden_ratio=3.0, beta=0.2)
+    assert net.activation == "softmax"
+    assert net.order == 4
+    assert net.hidden_dim == 12
+    assert net.temperature == pytest.approx(0.2)
+
+    g = torch.randn(2, 5, 4)
+    energy = net(g)
+    assert torch.isfinite(energy)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_simplicial_hopfield_mixed_precision(dtype: torch.dtype) -> None:
+    """Test mixed precision support."""
+    torch.manual_seed(42)
+    net = SimplicialHopfieldNetwork(2, hidden_dim=2, order=3, activation="relu")
+
+    g = torch.randn(1, 3, 2, dtype=dtype)
+    energy = net(g)
+    assert energy.dtype == dtype
+
+    grad = net.compute_grad(g)
+    assert grad.dtype == dtype
+
+
+def test_simplicial_hopfield_energy_decreases() -> None:
+    """Test that energy decreases with proper optimization."""
+    from energy_transformer.layers import (
+        EnergyLayerNorm,
+        MultiheadEnergyAttention,
+    )
+    from energy_transformer.models import EnergyTransformer
+    from energy_transformer.testing import assert_energy_decreases
+    from energy_transformer.utils import SGD
+
+    et_block = EnergyTransformer(
+        layer_norm=EnergyLayerNorm(8),
+        attention=MultiheadEnergyAttention(8, num_heads=2),
+        hopfield=SimplicialHopfieldNetwork(8, hidden_dim=16, order=3),
+        steps=10,
+        optimizer=SGD(alpha=0.1),
+    )
+
+    x = torch.randn(2, 4, 8)
+    assert_energy_decreases(et_block, x, tolerance=1e-6)

--- a/tests/unit/models/vision/test_viset.py
+++ b/tests/unit/models/vision/test_viset.py
@@ -1,0 +1,383 @@
+"""Unit tests for Vision Simplicial Energy Transformer (ViSET)."""
+
+from dataclasses import dataclass
+
+import pytest
+import torch
+from torch import nn
+
+from energy_transformer.models.vision import viset
+
+
+@dataclass
+class ETOutput:
+    tokens: torch.Tensor
+    final_energy: torch.Tensor | None
+    trajectory: torch.Tensor | None
+
+
+pytestmark = pytest.mark.unit
+
+
+class DummyET(nn.Module):
+    """Simple ET block that increments tokens and optionally returns energy."""
+
+    def __init__(self, energy: float, trajectory: list[float]):
+        super().__init__()
+        self.energy = energy
+        self.trajectory = trajectory
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        track: str = "none",
+        **_: object,
+    ) -> torch.Tensor | ETOutput:
+        x = x + 1
+
+        return_energy = track in ("energy", "both")
+        return_trajectory = track in ("trajectory", "both")
+
+        energy = torch.tensor(self.energy) if return_energy else None
+        traj = torch.tensor(self.trajectory) if return_trajectory else None
+
+        if return_energy or return_trajectory:
+            return ETOutput(tokens=x, final_energy=energy, trajectory=traj)
+        return x
+
+
+def _make_model(depth: int = 0) -> viset.VisionSimplicialTransformer:
+    return viset.VisionSimplicialTransformer(
+        img_size=4,
+        patch_size=2,
+        in_chans=3,
+        num_classes=5,
+        embed_dim=8,
+        depth=depth,
+        num_heads=1,
+        _head_dim=4,
+        hopfield_hidden_dim=8,
+        et_steps=1,
+        et_alpha=0.1,
+        order=3,
+        drop_rate=0.0,
+    )
+
+
+def test_process_blocks_without_energy_info() -> None:
+    """Test processing blocks without energy tracking."""
+    model = _make_model()
+    model.et_blocks = nn.ModuleList([DummyET(0.5, [0.1]), DummyET(1.0, [0.2])])
+    x = torch.zeros(1, 5, 8)
+    out, info = model._process_et_blocks(x, False, {})
+    assert torch.allclose(out, torch.full_like(x, 2.0))
+    assert info == {}
+
+
+def test_process_blocks_with_energy_info() -> None:
+    """Test processing blocks with energy tracking."""
+    model = _make_model()
+    model.et_blocks = nn.ModuleList([DummyET(0.5, [0.1]), DummyET(1.0, [0.2])])
+    x = torch.zeros(1, 5, 8)
+    out, info = model._process_et_blocks(x, True, {})
+    assert torch.allclose(out, torch.full_like(x, 2.0))
+
+    assert info["block_energies"] == pytest.approx([0.5, 1.0])
+    assert info["total_energy"] == pytest.approx(1.5)
+    assert len(info["block_trajectories"]) == 2
+
+    import numpy as np
+
+    np.testing.assert_array_almost_equal(
+        info["block_trajectories"][0], np.array([0.1])
+    )
+    np.testing.assert_array_almost_equal(
+        info["block_trajectories"][1], np.array([0.2])
+    )
+
+
+def test_forward_raises_for_wrong_image_size() -> None:
+    """Test that wrong image size raises ValueError."""
+    model = _make_model()
+    img = torch.zeros(1, 3, 2, 4)
+    with pytest.raises(ValueError, match="Input size"):
+        model(img)
+
+
+def test_forward_returns_logits() -> None:
+    """Test forward pass returns logits."""
+    model = _make_model()
+    model.et_blocks = nn.ModuleList([DummyET(0.2, [0.1])])
+    img = torch.zeros(1, 3, 4, 4)
+    out = model(img)
+    assert out.shape == (1, 5)
+    assert torch.all(out == 0)
+
+
+def test_forward_features_and_energy_info() -> None:
+    """Test returning features and energy info."""
+    model = _make_model()
+    model.et_blocks = nn.ModuleList([DummyET(0.2, [0.1])])
+    img = torch.zeros(1, 3, 4, 4)
+    result = model(img, return_features=True, return_energy_info=True)
+    assert set(result.keys()) == {"features", "energy_info"}
+    assert result["features"].shape == (1, 8)
+
+    assert result["energy_info"]["block_energies"] == pytest.approx([0.2])
+
+
+def test_factory_functions(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test factory functions create correct configurations."""
+    factories = [
+        (
+            viset.viset_tiny,
+            {
+                "embed_dim": 192,
+                "depth": 12,
+                "num_heads": 3,
+                "_head_dim": 64,
+                "hopfield_hidden_dim": 768,
+                "et_steps": 4,
+                "et_alpha": 0.125,
+                "order": 3,
+                "in_chans": 3,
+            },
+        ),
+        (
+            viset.viset_small,
+            {
+                "embed_dim": 384,
+                "depth": 12,
+                "num_heads": 6,
+                "_head_dim": 64,
+                "hopfield_hidden_dim": 1536,
+                "et_steps": 4,
+                "et_alpha": 0.125,
+                "order": 3,
+                "in_chans": 3,
+            },
+        ),
+        (
+            viset.viset_base,
+            {
+                "embed_dim": 768,
+                "depth": 12,
+                "num_heads": 12,
+                "_head_dim": 64,
+                "hopfield_hidden_dim": 3072,
+                "et_steps": 4,
+                "et_alpha": 0.125,
+                "order": 3,
+                "in_chans": 3,
+            },
+        ),
+        (
+            viset.viset_large,
+            {
+                "embed_dim": 1024,
+                "depth": 24,
+                "num_heads": 16,
+                "_head_dim": 64,
+                "hopfield_hidden_dim": 4096,
+                "et_steps": 4,
+                "et_alpha": 0.125,
+                "order": 3,
+                "in_chans": 3,
+            },
+        ),
+        (
+            viset.viset_tiny_cifar,
+            {
+                "img_size": 32,
+                "patch_size": 4,
+                "in_chans": 3,
+                "num_classes": 100,
+                "embed_dim": 192,
+                "depth": 12,
+                "num_heads": 3,
+                "_head_dim": 64,
+                "hopfield_hidden_dim": 768,
+                "et_steps": 4,
+                "et_alpha": 0.125,
+                "order": 3,
+                "drop_rate": 0.1,
+            },
+        ),
+        (
+            viset.viset_small_cifar,
+            {
+                "img_size": 32,
+                "patch_size": 4,
+                "in_chans": 3,
+                "num_classes": 100,
+                "embed_dim": 384,
+                "depth": 12,
+                "num_heads": 6,
+                "_head_dim": 64,
+                "hopfield_hidden_dim": 1536,
+                "et_steps": 4,
+                "et_alpha": 0.125,
+                "order": 3,
+                "drop_rate": 0.1,
+            },
+        ),
+        (
+            viset.viset_2l_cifar,
+            {
+                "img_size": 32,
+                "patch_size": 4,
+                "in_chans": 3,
+                "num_classes": 100,
+                "embed_dim": 192,
+                "depth": 2,
+                "num_heads": 8,
+                "_head_dim": 64,
+                "hopfield_hidden_dim": 576,
+                "et_steps": 6,
+                "et_alpha": 10.0,
+                "order": 3,
+                "drop_rate": 0.1,
+            },
+        ),
+        (
+            viset.viset_4l_cifar,
+            {
+                "img_size": 32,
+                "patch_size": 4,
+                "in_chans": 3,
+                "num_classes": 100,
+                "embed_dim": 192,
+                "depth": 4,
+                "num_heads": 8,
+                "_head_dim": 64,
+                "hopfield_hidden_dim": 576,
+                "et_steps": 5,
+                "et_alpha": 5.0,
+                "order": 3,
+                "drop_rate": 0.1,
+            },
+        ),
+        (
+            viset.viset_6l_cifar,
+            {
+                "img_size": 32,
+                "patch_size": 4,
+                "in_chans": 3,
+                "num_classes": 100,
+                "embed_dim": 192,
+                "depth": 6,
+                "num_heads": 8,
+                "_head_dim": 64,
+                "hopfield_hidden_dim": 576,
+                "et_steps": 4,
+                "et_alpha": 2.5,
+                "order": 3,
+                "drop_rate": 0.1,
+            },
+        ),
+    ]
+
+    def capture(**kwargs: object) -> dict[str, object]:
+        return kwargs
+
+    monkeypatch.setattr(viset, "VisionSimplicialTransformer", capture)
+
+    for factory, expected in factories:
+        cfg = factory(extra=1)
+        assert cfg == {**expected, "extra": 1}
+
+
+def test_viset_with_different_orders() -> None:
+    """Test ViSET with different simplicial orders."""
+    for order in [2, 3, 4, 5]:
+        model = viset.viset_2l_cifar(num_classes=10, order=order)
+        assert model.order == order
+        for et_block in model.et_blocks:
+            assert et_block.hopfield.order == order
+        img = torch.randn(2, 3, 32, 32)
+        out = model(img)
+        assert out.shape == (2, 10)
+
+
+def test_viset_with_softmax_hopfield() -> None:
+    """Test ViSET with softmax activation in Simplicial Hopfield."""
+    model = viset.viset_2l_cifar(
+        num_classes=10,
+        hopfield_activation="softmax",
+        hopfield_beta=0.2,
+    )
+    for et_block in model.et_blocks:
+        assert et_block.hopfield.activation == "softmax"
+        assert et_block.hopfield.temperature == pytest.approx(0.2)
+
+    img = torch.randn(2, 3, 32, 32)
+    out = model(img)
+    assert out.shape == (2, 10)
+
+
+def test_viset_real_forward_pass() -> None:
+    """Test a real forward pass with actual ET blocks."""
+    model = viset.viset_2l_cifar(num_classes=10)
+
+    img = torch.randn(4, 3, 32, 32)
+    out = model(img)
+    assert out.shape == (4, 10)
+
+    features = model(img, return_features=True)
+    assert features.shape == (4, 192)
+
+    result = model(img, return_energy_info=True)
+    assert "logits" in result
+    assert "energy_info" in result
+    assert result["logits"].shape == (4, 10)
+    assert len(result["energy_info"]["block_energies"]) == 2
+
+
+def test_viset_patch_embedding() -> None:
+    """Test patch embedding dimensions."""
+    model = viset.viset_2l_cifar(num_classes=10)
+    assert model.patch_embed.num_patches == 64
+    assert model.patch_embed.patch_size == (4, 4)
+
+    img = torch.randn(2, 3, 32, 32)
+    patches = model.patch_embed(img)
+    assert patches.shape == (2, 64, 192)
+
+
+def test_viset_cls_token_and_positional_embedding() -> None:
+    """Test CLS token and positional embeddings."""
+    model = viset.viset_2l_cifar(num_classes=10)
+    assert model.cls_token.shape == (1, 1, 192)
+    assert model.pos_embed.pos_embed.shape == (65, 192)
+    assert model.pos_embed.cls_token is True
+
+
+def test_viset_memory_efficiency() -> None:
+    """Test that ViSET can handle reasonable batch sizes."""
+    model = viset.viset_2l_cifar(num_classes=10)
+    img = torch.randn(32, 3, 32, 32)
+    with torch.no_grad():
+        out = model(img, et_kwargs={"detach": True})
+    assert out.shape == (32, 10)
+
+
+def test_viset_gradient_flow() -> None:
+    """Test that gradients flow through ViSET."""
+    model = viset.viset_2l_cifar(num_classes=10)
+    img = torch.randn(2, 3, 32, 32, requires_grad=True)
+    out = model(img)
+    loss = out.mean()
+    loss.backward()
+    assert img.grad is not None
+    # Classification head should receive gradients during training
+    assert model.head.fc.weight.grad is not None
+
+
+def test_viset_initialization() -> None:
+    """Test proper initialization of ViSET components."""
+    model = viset.viset_2l_cifar(num_classes=10)
+    assert model.cls_token.abs().max() < 0.1
+    assert model.pos_embed.pos_embed.abs().max() < 0.1
+    assert torch.allclose(
+        model.head.fc.weight, torch.zeros_like(model.head.fc.weight)
+    )


### PR DESCRIPTION
## Summary
- implement simplicial Hopfield network layer
- add VisionSimplicialTransformer with factory configs
- expose modules in package initializers
- document mathematical foundations of energy-based layers
- clarify token update gradients and fix gradient tests

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68426199f1bc832bbd2214b030bb6bdc