### PR TITLE
[models] drop unused head_dim

### DIFF
--- a/energy_transformer/layers/heads.py
+++ b/energy_transformer/layers/heads.py
@@ -70,18 +70,19 @@ class BaseClassifierHead(nn.Module):
 
     @staticmethod
     def _create_pool(pool_type: PoolType) -> nn.Module:
-        if pool_type == "avg":
-            return _GlobalAvgPool()
-        if pool_type == "max":
-            return _GlobalMaxPool()
-        if pool_type == "token":
-            return _TokenPool()
-        if pool_type == "none":
-            return nn.Identity()
-        raise ValueError(
-            f"BaseClassifierHead: Unknown pool_type '{pool_type}'. "
-            "Expected one of: 'avg', 'max', 'token', 'none'."
-        )
+        """Return pooling layer based on ``pool_type``."""
+        pools: dict[PoolType, nn.Module] = {
+            "avg": _GlobalAvgPool(),
+            "max": _GlobalMaxPool(),
+            "token": _TokenPool(),
+            "none": nn.Identity(),
+        }
+        if pool_type not in pools:
+            raise ValueError(
+                f"BaseClassifierHead: Unknown pool_type '{pool_type}'. "
+                "Expected one of: 'avg', 'max', 'token', 'none'."
+            )
+        return pools[pool_type]
 
     def _init_linear_zero(self, layer: nn.Linear) -> None:
         nn.init.zeros_(layer.weight)

--- a/energy_transformer/models/vision/viet.py
+++ b/energy_transformer/models/vision/viet.py
@@ -106,8 +106,6 @@ class VisionEnergyTransformer(nn.Module):  # type: ignore[misc]
         Number of Energy Transformer blocks.
     num_heads : int
         Number of attention heads.
-    head_dim : int
-        Dimension of each attention head.
     hopfield_hidden_dim : int
         Hidden dimension for Hopfield networks.
     et_steps : int
@@ -127,7 +125,6 @@ class VisionEnergyTransformer(nn.Module):  # type: ignore[misc]
         embed_dim: int,
         depth: int,
         num_heads: int,
-        _head_dim: int,
         hopfield_hidden_dim: int,
         et_steps: int,
         drop_rate: float = 0.0,
@@ -270,7 +267,6 @@ def viet_tiny(**kwargs: Any) -> VisionEnergyTransformer:
         "embed_dim": 192,
         "depth": 12,
         "num_heads": 3,
-        "_head_dim": 64,
         "hopfield_hidden_dim": 768,  # 4x embed_dim
         "et_steps": 4,
         "in_chans": 3,
@@ -285,7 +281,6 @@ def viet_small(**kwargs: Any) -> VisionEnergyTransformer:
         "embed_dim": 384,
         "depth": 12,
         "num_heads": 6,
-        "_head_dim": 64,
         "hopfield_hidden_dim": 1536,  # 4x embed_dim
         "et_steps": 4,
         "in_chans": 3,
@@ -300,7 +295,6 @@ def viet_base(**kwargs: Any) -> VisionEnergyTransformer:
         "embed_dim": 768,
         "depth": 12,
         "num_heads": 12,
-        "_head_dim": 64,
         "hopfield_hidden_dim": 3072,  # 4x embed_dim
         "et_steps": 4,
         "in_chans": 3,
@@ -315,7 +309,6 @@ def viet_large(**kwargs: Any) -> VisionEnergyTransformer:
         "embed_dim": 1024,
         "depth": 24,
         "num_heads": 16,
-        "_head_dim": 64,
         "hopfield_hidden_dim": 4096,  # 4x embed_dim
         "et_steps": 4,
         "in_chans": 3,
@@ -340,7 +333,6 @@ def viet_tiny_cifar(
         "embed_dim": 192,
         "depth": 12,
         "num_heads": 3,
-        "_head_dim": 64,
         "hopfield_hidden_dim": 768,
         "et_steps": 4,
         "drop_rate": 0.1,
@@ -362,7 +354,6 @@ def viet_small_cifar(
         "embed_dim": 384,
         "depth": 12,
         "num_heads": 6,
-        "_head_dim": 64,
         "hopfield_hidden_dim": 1536,
         "et_steps": 4,
         "drop_rate": 0.1,
@@ -387,7 +378,6 @@ def viet_2l_cifar(
         "embed_dim": 192,
         "depth": 2,  # Shallow!
         "num_heads": 8,
-        "_head_dim": 64,
         "hopfield_hidden_dim": 576,  # 3x embed_dim
         "et_steps": 6,
         "drop_rate": 0.1,
@@ -409,7 +399,6 @@ def viet_4l_cifar(
         "embed_dim": 192,
         "depth": 4,
         "num_heads": 8,
-        "_head_dim": 64,
         "hopfield_hidden_dim": 576,
         "et_steps": 5,
         "drop_rate": 0.1,
@@ -431,7 +420,6 @@ def viet_6l_cifar(
         "embed_dim": 192,
         "depth": 6,
         "num_heads": 8,
-        "_head_dim": 64,
         "hopfield_hidden_dim": 576,
         "et_steps": 4,
         "drop_rate": 0.1,

--- a/energy_transformer/models/vision/viset.py
+++ b/energy_transformer/models/vision/viset.py
@@ -51,8 +51,6 @@ class VisionSimplicialTransformer(nn.Module):
         Number of Energy Transformer blocks.
     num_heads : int
         Number of attention heads.
-    _head_dim : int
-        Dimension of each attention head (for compatibility).
     hopfield_hidden_dim : int
         Hidden dimension for Simplicial Hopfield networks.
     et_steps : int
@@ -76,7 +74,6 @@ class VisionSimplicialTransformer(nn.Module):
         embed_dim: int,
         depth: int,
         num_heads: int,
-        _head_dim: int,
         hopfield_hidden_dim: int,
         et_steps: int,
         drop_rate: float = 0.0,
@@ -181,7 +178,6 @@ def viset_tiny(**kwargs: Any) -> VisionSimplicialTransformer:
         "embed_dim": 192,
         "depth": 12,
         "num_heads": 3,
-        "_head_dim": 64,
         "hopfield_hidden_dim": 768,
         "et_steps": 4,
         "in_chans": 3,
@@ -197,7 +193,6 @@ def viset_small(**kwargs: Any) -> VisionSimplicialTransformer:
         "embed_dim": 384,
         "depth": 12,
         "num_heads": 6,
-        "_head_dim": 64,
         "hopfield_hidden_dim": 1536,
         "et_steps": 4,
         "in_chans": 3,
@@ -213,7 +208,6 @@ def viset_base(**kwargs: Any) -> VisionSimplicialTransformer:
         "embed_dim": 768,
         "depth": 12,
         "num_heads": 12,
-        "_head_dim": 64,
         "hopfield_hidden_dim": 3072,
         "et_steps": 4,
         "in_chans": 3,
@@ -229,7 +223,6 @@ def viset_large(**kwargs: Any) -> VisionSimplicialTransformer:
         "embed_dim": 1024,
         "depth": 24,
         "num_heads": 16,
-        "_head_dim": 64,
         "hopfield_hidden_dim": 4096,
         "et_steps": 4,
         "in_chans": 3,
@@ -251,7 +244,6 @@ def viset_tiny_cifar(
         "embed_dim": 192,
         "depth": 12,
         "num_heads": 3,
-        "_head_dim": 64,
         "hopfield_hidden_dim": 768,
         "et_steps": 4,
         "drop_rate": 0.1,
@@ -273,7 +265,6 @@ def viset_small_cifar(
         "embed_dim": 384,
         "depth": 12,
         "num_heads": 6,
-        "_head_dim": 64,
         "hopfield_hidden_dim": 1536,
         "et_steps": 4,
         "drop_rate": 0.1,
@@ -295,7 +286,6 @@ def viset_2l_cifar(
         "embed_dim": 192,
         "depth": 2,
         "num_heads": 8,
-        "_head_dim": 64,
         "hopfield_hidden_dim": 192,
         "et_steps": 6,
         "drop_rate": 0.1,
@@ -317,7 +307,6 @@ def viset_4l_cifar(
         "embed_dim": 192,
         "depth": 4,
         "num_heads": 8,
-        "_head_dim": 64,
         "hopfield_hidden_dim": 192,
         "et_steps": 5,
         "drop_rate": 0.1,
@@ -339,7 +328,6 @@ def viset_6l_cifar(
         "embed_dim": 192,
         "depth": 6,
         "num_heads": 8,
-        "_head_dim": 64,
         "hopfield_hidden_dim": 192,
         "et_steps": 4,
         "drop_rate": 0.1,


### PR DESCRIPTION
## Summary
- remove `_head_dim` parameter from ViET and ViSET
- update factory configs accordingly
- refactor pooling layer selection in classifier heads

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy .` *(fails: command not found)*
- `pytest -m "not slow"`

------
https://chatgpt.com/codex/tasks/task_e_68447c34635c832b80364b9e4e34ad98