### PR TITLE
[models] drop unused compatibility arg

### DIFF
--- a/energy_transformer/layers/constants.py
+++ b/energy_transformer/layers/constants.py
@@ -26,7 +26,6 @@ __all__ = [
     "MIXED_PRECISION_DTYPES",
     "SMALL_INIT_STD",
     "ZERO_INIT_STD",
-    "PoolType",
 ]
 
 # Numerical stability constants
@@ -63,12 +62,3 @@ DEFAULT_COMPUTE_DTYPE: torch.dtype = torch.float32
 # Dimension thresholds
 MEMORY_EFFICIENT_SEQ_THRESHOLD: int = 512
 MIN_SEQUENCE_LENGTH: int = 1
-
-
-class PoolType:
-    """String constants for pooling types."""
-
-    TOKEN = "token"  # noqa: S105
-    AVG = "avg"
-    MAX = "max"
-    NONE = "none"

--- a/energy_transformer/layers/simplicial.py
+++ b/energy_transformer/layers/simplicial.py
@@ -153,7 +153,7 @@ class SimplicialHopfieldNetwork(nn.Module):
         Tensor
             Scalar energy value averaged over batch, tokens, and simplices.
         """
-        b, n, _ = g.shape
+        b, n = g.shape[:2]
         device = g.device
         edges, triangles = self._choose_simplices(n, device)
         num_simplices = edges.size(0) + triangles.size(0)

--- a/energy_transformer/models/vision/viet.py
+++ b/energy_transformer/models/vision/viet.py
@@ -112,8 +112,6 @@ class VisionEnergyTransformer(nn.Module):  # type: ignore[misc]
         Number of energy optimization steps per block.
     drop_rate : float
         Dropout rate.
-    representation_size : int | None
-        Size of representation layer before classification head.
     """
 
     def __init__(
@@ -128,7 +126,6 @@ class VisionEnergyTransformer(nn.Module):  # type: ignore[misc]
         hopfield_hidden_dim: int,
         et_steps: int,
         drop_rate: float = 0.0,
-        _representation_size: int | None = None,
     ) -> None:
         """Initialize VisionImageTransformer."""
         super().__init__()

--- a/energy_transformer/models/vision/viset.py
+++ b/energy_transformer/models/vision/viset.py
@@ -57,8 +57,6 @@ class VisionSimplicialTransformer(nn.Module):
         Number of energy optimization steps per block.
     drop_rate : float
         Dropout rate.
-    _representation_size : int | None
-        Size of representation layer (for compatibility).
     hopfield_beta : float
         Inverse temperature for Simplicial Hopfield.
     triangle_fraction : float
@@ -77,7 +75,6 @@ class VisionSimplicialTransformer(nn.Module):
         hopfield_hidden_dim: int,
         et_steps: int,
         drop_rate: float = 0.0,
-        _representation_size: int | None = None,
         hopfield_beta: float = 0.1,
         triangle_fraction: float = 0.5,
     ) -> None:


### PR DESCRIPTION
## Summary
- remove unused `_representation_size` arguments from vision models

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68447fca1bf4832baa7c93f8cd5ed4f4