### PR TITLE
[docs] refine docstrings and cleanup

### DIFF
--- a/energy_transformer/models/base.py
+++ b/energy_transformer/models/base.py
@@ -18,7 +18,19 @@ __all__ = ["EnergyTransformer"]
 
 
 class EnergyTransformer(nn.Module):
-    """Energy Transformer with direct gradient descent."""
+    """Energy Transformer core module.
+
+    Parameters
+    ----------
+    layer_norm : nn.Module
+        Normalization layer used before each energy component.
+    attention : MultiheadEnergyAttention
+        Energy-based attention module.
+    hopfield : HopfieldNetwork | SimplicialHopfieldNetwork
+        Associative memory module.
+    steps : int, default=12
+        Number of iterative refinement steps.
+    """
 
     def __init__(
         self,
@@ -41,7 +53,20 @@ class EnergyTransformer(nn.Module):
     def forward(
         self, x: Tensor, return_energies: bool = False
     ) -> Tensor | tuple[Tensor, list[tuple[Tensor, Tensor]]]:
-        """Run iterative energy minimization."""
+        """Run iterative energy minimization.
+
+        Parameters
+        ----------
+        x : Tensor
+            Input tensor of shape ``(B, N, D)``.
+        return_energies : bool, default=False
+            If ``True`` return average attention and Hopfield energies.
+
+        Returns
+        -------
+        Tensor | tuple[Tensor, list[tuple[Tensor, Tensor]]]
+            Output tensor, optionally with energy history.
+        """
         residual = x.clone()
 
         for _ in range(self.steps):

--- a/energy_transformer/models/vision/viet.py
+++ b/energy_transformer/models/vision/viet.py
@@ -2,6 +2,8 @@
 
 Vision Transformer variant using energy-based components such as
 :class:`MultiheadEnergyAttention` and :class:`HopfieldNetwork`.
+It is based on the Energy Transformer architecture described in
+[Hoover2023ViET]_.
 
 References
 ----------

--- a/energy_transformer/models/vision/viet.py
+++ b/energy_transformer/models/vision/viet.py
@@ -1,54 +1,13 @@
-"""Vision Energy Transformer (ViET) implementation.
+"""Vision Energy Transformer (ViET).
 
-This module implements the Vision Energy Transformer, which replaces standard
-transformer components with energy-based alternatives as described in
-"Energy Transformer" (Hoover et al., 2023). See [Hoover2023ViET]_ for details.
-
-from __future__ import annotations
-
-Key Differences from Standard ViT
----------------------------------
-- Multi-Head Energy Attention instead of standard self-attention
-- Hopfield Networks instead of MLP blocks
-- Energy-based LayerNorm with learnable temperature
-- Iterative refinement through gradient descent on energy landscape
-
-Classes
--------
-VisionEnergyTransformer
-    Main ViET model that orchestrates energy-based components
-
-Factory Functions
------------------
-viet_tiny, viet_small, viet_base, viet_large
-    Standard configurations matching ViT sizes
-viet_tiny_cifar, viet_small_cifar
-    CIFAR-optimized configurations
-viet_2l_cifar, viet_4l_cifar, viet_6l_cifar
-    Shallow variants for computational efficiency
-
-Example
--------
->>> # Create a 2-layer ViET for CIFAR-100
->>> model = viet_2l_cifar(num_classes=100)
->>>
->>> # Forward pass with energy information
->>> images = torch.randn(32, 3, 32, 32)
->>> result = model(images, return_energy_info=True)
->>> logits = result['logits']
->>> energy_trajectory = result['energy_info']['block_energies']
-
-Parameters
-----------
-The key hyperparameters for ViET are:
-- `et_steps`: Number of energy minimization steps (default: 4-6)
-- `hopfield_hidden_dim`: Hidden dimension for Hopfield networks
+Vision Transformer variant using energy-based components such as
+:class:`MultiheadEnergyAttention` and :class:`HopfieldNetwork`.
 
 References
 ----------
-.. [Hoover2023ViET] Hoover, B., Liang, Y., Pham, B., Panda, R., Strobelt, H., Chau, D. H.,
-       Zaki, M. J., & Krotov, D. (2023). Energy Transformer.
-       arXiv preprint arXiv:2302.07253.
+.. [Hoover2023ViET] Hoover, B., Liang, Y., Pham, B., Panda, R., Strobelt, H.,
+   Chau, D. H., Zaki, M. J., & Krotov, D. (2023). *Energy Transformer*.
+   arXiv preprint arXiv:2302.07253.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- clean up ViET module docstring
- enrich docstrings in core modules
- improve energy attention and Hopfield docs

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy .`
- `pytest tests/ -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a5a1e4c4832b8206ec4eee02c3f5