### PR TITLE
Improve docstrings and rebuild docs

### DIFF
--- a/energy_transformer/__init__.py
+++ b/energy_transformer/__init__.py
@@ -15,7 +15,23 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 def __getattr__(name: str) -> object:
-    """Lazy load modules and attributes."""
+    """Lazy load modules and attributes on demand.
+
+    Parameters
+    ----------
+    name : str
+        Attribute to retrieve from a lazily loaded submodule.
+
+    Returns
+    -------
+    object
+        The requested attribute.
+
+    Raises
+    ------
+    AttributeError
+        If ``name`` is not a known lazy attribute.
+    """
     if name in _LAZY_IMPORTS:
         module_name = _LAZY_IMPORTS[name]
         import importlib

--- a/energy_transformer/layers/__init__.py
+++ b/energy_transformer/layers/__init__.py
@@ -53,6 +53,23 @@ _ATTR_TO_MODULE = {
 
 
 def __getattr__(name: str) -> object:
+    """Dynamically import attributes on first access.
+
+    Parameters
+    ----------
+    name : str
+        Attribute name to resolve.
+
+    Returns
+    -------
+    object
+        Requested attribute from the appropriate submodule.
+
+    Raises
+    ------
+    AttributeError
+        If ``name`` is not a lazily-loadable attribute.
+    """
     module_name = _ATTR_TO_MODULE.get(name)
     if module_name is None:
         msg = f"module {__name__!r} has no attribute {name!r}"

--- a/energy_transformer/layers/heads.py
+++ b/energy_transformer/layers/heads.py
@@ -87,16 +87,44 @@ class BaseClassifierHead(nn.Module):
         return _POOLS[pool_type]
 
     def _init_linear_zero(self, layer: nn.Linear) -> None:
+        """Initialize linear layer weights to zeros.
+
+        Parameters
+        ----------
+        layer : nn.Linear
+            Layer to initialize.
+        """
         nn.init.zeros_(layer.weight)
         if layer.bias is not None:
             nn.init.zeros_(layer.bias)
 
     def _init_linear_normal(self, layer: nn.Linear, std: float = 0.02) -> None:
+        """Initialize linear layer with truncated normal weights.
+
+        Parameters
+        ----------
+        layer : nn.Linear
+            Layer to initialize.
+        std : float, default=0.02
+            Standard deviation of the normal distribution.
+        """
         nn.init.trunc_normal_(layer.weight, std=std)
         if layer.bias is not None:
             nn.init.zeros_(layer.bias)
 
     def _pool_features(self, x: Tensor) -> Tensor:
+        """Apply configured pooling to ``x``.
+
+        Parameters
+        ----------
+        x : Tensor
+            Input tensor of shape ``(B, N, C)`` or ``(B, C)``.
+
+        Returns
+        -------
+        Tensor
+            Pooled features.
+        """
         return cast(Tensor, self.pool(x))
 
     def extra_repr(self) -> str:

--- a/energy_transformer/layers/validation.py
+++ b/energy_transformer/layers/validation.py
@@ -11,7 +11,24 @@ def validate_tensor_dim(
     module_name: str,
     param_name: str = "input",
 ) -> None:
-    """Validate tensor dimensionality."""
+    """Validate tensor dimensionality.
+
+    Parameters
+    ----------
+    x : Tensor
+        Tensor to validate.
+    expected_dim : int
+        Required number of dimensions.
+    module_name : str
+        Name of the calling module for error context.
+    param_name : str, default="input"
+        Name of the parameter being checked.
+
+    Raises
+    ------
+    ValueError
+        If ``x`` does not have ``expected_dim`` dimensions.
+    """
     if x.dim() != expected_dim:
         msg = (
             f"{module_name}: {param_name} must be {expected_dim}D tensor. "
@@ -28,7 +45,27 @@ def validate_shape_match(
     param_name: str = "input",
     dims_to_check: Sequence[int] | None = None,
 ) -> None:
-    """Validate specific dimensions of tensor shape."""
+    """Validate specific dimensions of a tensor's shape.
+
+    Parameters
+    ----------
+    x : Tensor
+        Tensor to validate.
+    expected_shape : Sequence[int]
+        Expected shape with ``-1`` as a wildcard for any value.
+    module_name : str
+        Name of the calling module for error context.
+    param_name : str, default="input"
+        Name of the parameter being checked.
+    dims_to_check : Sequence[int] or None, optional
+        Indices of ``x``'s shape to check. If ``None`` all dimensions are
+        validated.
+
+    Raises
+    ------
+    ValueError
+        If any specified dimension does not match ``expected_shape``.
+    """
     if dims_to_check is None:
         dims_to_check = range(len(expected_shape))
 
@@ -57,7 +94,26 @@ def validate_divisibility(
     value_name: str,
     divisor_name: str,
 ) -> None:
-    """Validate that value is divisible by divisor."""
+    """Validate that ``value`` is divisible by ``divisor``.
+
+    Parameters
+    ----------
+    value : int
+        Value to check.
+    divisor : int
+        Divisor that ``value`` should be divisible by.
+    module_name : str
+        Name of the calling module for error context.
+    value_name : str
+        Name of the ``value`` parameter for error messages.
+    divisor_name : str
+        Name of the ``divisor`` parameter for error messages.
+
+    Raises
+    ------
+    ValueError
+        If ``value`` modulo ``divisor`` is not ``0``.
+    """
     if value % divisor != 0:
         msg = (
             f"{module_name}: {value_name} must be divisible by {divisor_name}. "
@@ -72,7 +128,22 @@ def validate_positive(
     module_name: str,
     param_name: str,
 ) -> None:
-    """Validate that value is positive."""
+    """Validate that ``value`` is positive.
+
+    Parameters
+    ----------
+    value : float
+        Value to check.
+    module_name : str
+        Name of the calling module for error context.
+    param_name : str
+        Name of the parameter being checked.
+
+    Raises
+    ------
+    ValueError
+        If ``value`` is not strictly positive.
+    """
     if value <= 0:
         msg = (
             f"{module_name}: {param_name} must be positive. "
@@ -87,7 +158,24 @@ def format_shape_error(
     actual: str,
     context: str = "",
 ) -> str:
-    """Format a standardized shape error message."""
+    """Format a standardized shape error message.
+
+    Parameters
+    ----------
+    module_name : str
+        Name of the module reporting the error.
+    expected : str
+        Human readable description of the expected shape.
+    actual : str
+        Human readable description of the actual shape.
+    context : str, default=""
+        Additional context appended to the error message.
+
+    Returns
+    -------
+    str
+        Formatted error string.
+    """
     msg = f"{module_name}: Shape mismatch"
     if context:
         msg += f" {context}"

--- a/energy_transformer/models/__init__.py
+++ b/energy_transformer/models/__init__.py
@@ -11,6 +11,23 @@ __all__ = ["EnergyTransformer"]
 
 
 def __getattr__(name: str) -> object:
+    """Lazily import the :class:`EnergyTransformer` model.
+
+    Parameters
+    ----------
+    name : str
+        Attribute being requested.
+
+    Returns
+    -------
+    object
+        The requested attribute.
+
+    Raises
+    ------
+    AttributeError
+        If ``name`` is not ``"EnergyTransformer"``.
+    """
     if name == "EnergyTransformer":
         from .base import EnergyTransformer
 

--- a/energy_transformer/models/vision/__init__.py
+++ b/energy_transformer/models/vision/__init__.py
@@ -105,6 +105,23 @@ _ATTR_TO_MODULE = {
 
 
 def __getattr__(name: str) -> object:
+    """Lazily resolve vision model attributes.
+
+    Parameters
+    ----------
+    name : str
+        Attribute name to import from a submodule.
+
+    Returns
+    -------
+    object
+        The requested attribute.
+
+    Raises
+    ------
+    AttributeError
+        If ``name`` is not recognized.
+    """
     module_name = _ATTR_TO_MODULE.get(name)
     if module_name is None:
         msg = f"module {__name__!r} has no attribute {name!r}"


### PR DESCRIPTION
## Summary
- document lazy attribute helpers
- expand validation utilities' docs
- detail initialization helpers for classifier heads
- regenerate HTML docs using Sphinx

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy .`
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_6844af6d3c98832b8d61bdbf7eca4e5d