### PR TITLE
Comprehensive cleanup of transformer models

### DIFF
--- a/energy_transformer/models/base.py
+++ b/energy_transformer/models/base.py
@@ -50,31 +50,28 @@ class EnergyTransformer(nn.Module):
         self.alpha = DEFAULT_ALPHA
         self.skip_scale = nn.Parameter(torch.ones(1) * DEFAULT_SKIP_SCALE_INIT)
 
+    def _step(self, x: Tensor) -> Tensor:
+        """Perform a single energy minimization step."""
+        g = self.layer_norm(x)
+        x = x - self.alpha * self.attention.compute_grad(g)
+        g = self.layer_norm(x)
+        return x - self.alpha * self.hopfield.compute_grad(g)
+
+    def _compute_energies(self, x: Tensor) -> tuple[Tensor, Tensor]:
+        """Return attention and Hopfield energies without gradients."""
+        g = self.layer_norm(x)
+        e_att = self.attention.compute_energy(g)
+        e_hop = self.hopfield.compute_energy(g)
+        return e_att, e_hop
+
     def forward(
         self, x: Tensor, return_energies: bool = False
     ) -> Tensor | tuple[Tensor, list[tuple[Tensor, Tensor]]]:
-        """Run iterative energy minimization.
-
-        Parameters
-        ----------
-        x : Tensor
-            Input tensor of shape ``(B, N, D)``.
-        return_energies : bool, default=False
-            If ``True`` return average attention and Hopfield energies.
-
-        Returns
-        -------
-        Tensor | tuple[Tensor, list[tuple[Tensor, Tensor]]]
-            Output tensor, optionally with energy history.
-        """
+        """Run iterative energy minimization."""
         residual = x.clone()
 
         for _ in range(self.steps):
-            g = self.layer_norm(x)
-            x = x - self.alpha * self.attention.compute_grad(g)
-
-            g = self.layer_norm(x)
-            x = x - self.alpha * self.hopfield.compute_grad(g)
+            x = self._step(x)
 
         out = x + self.skip_scale * residual
 
@@ -82,7 +79,6 @@ class EnergyTransformer(nn.Module):
             return out
 
         with torch.no_grad():
-            g = self.layer_norm(out)
-            e_att = self.attention.compute_energy(g)
-            e_hop = self.hopfield.compute_energy(g)
+            e_att, e_hop = self._compute_energies(out)
+
         return out, [(e_att, e_hop)]

--- a/energy_transformer/models/vision/viet.py
+++ b/energy_transformer/models/vision/viet.py
@@ -41,7 +41,7 @@ from energy_transformer.layers.validation import validate_shape_match
 from energy_transformer.models.base import EnergyTransformer
 
 
-class VisionEnergyTransformer(nn.Module):  # type: ignore[misc]
+class VisionEnergyTransformer(nn.Module):
     """Vision Energy Transformer (ViET).
 
     A Vision Transformer that replaces standard components with energy-based

--- a/energy_transformer/models/vision/vit.py
+++ b/energy_transformer/models/vision/vit.py
@@ -65,7 +65,7 @@ import torch
 from torch import Tensor, nn
 
 
-class PatchEmbedding(nn.Module):  # type: ignore[misc]
+class PatchEmbedding(nn.Module):
     """Convert image into patch embeddings."""
 
     def __init__(
@@ -105,7 +105,7 @@ class PatchEmbedding(nn.Module):  # type: ignore[misc]
         return x.flatten(2).transpose(1, 2)  # (B, N, D)
 
 
-class VisionTransformer(nn.Module):  # type: ignore[misc]
+class VisionTransformer(nn.Module):
     """Vision Transformer (ViT).
 
     Parameters
@@ -235,7 +235,7 @@ class VisionTransformer(nn.Module):  # type: ignore[misc]
         return cast(Tensor, self.head(x))
 
 
-class TransformerBlock(nn.Module):  # type: ignore[misc]
+class TransformerBlock(nn.Module):
     """Transformer block with attention and MLP."""
 
     def __init__(
@@ -281,7 +281,7 @@ class TransformerBlock(nn.Module):  # type: ignore[misc]
         return x + cast(Tensor, self.mlp(self.norm2(x)))
 
 
-class Attention(nn.Module):  # type: ignore[misc]
+class Attention(nn.Module):
     """Multi-head self-attention."""
 
     def __init__(
@@ -340,7 +340,7 @@ class Attention(nn.Module):  # type: ignore[misc]
         return cast(Tensor, self.proj_drop(x))
 
 
-class MLP(nn.Module):  # type: ignore[misc]
+class MLP(nn.Module):
     """MLP block with GELU activation."""
 
     def __init__(


### PR DESCRIPTION
## Summary
- refactor `EnergyTransformer.forward` into smaller helpers
- remove stale `type: ignore` comments from ViT and ViET

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy .` *(fails: Interrupted)*
- `pytest tests/ -q`

------
https://chatgpt.com/codex/tasks/task_e_6844bb50000c832b80d0653c7ca3a797