### PR TITLE
Fix RTD Sphinx versions

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,14 +20,8 @@ sphinx:
   configuration: docs/conf.py
   builder: html
   fail_on_warning: false  # Set to true after initial setup
+  version: "6.2.1"
 
-# Python environment
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
 
 # Build PDF & ePub
 formats:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,10 +1,10 @@
 # Core dependencies needed for building docs
-sphinx==8.1.3
-sphinx-autodoc-typehints==1.25.2
-pydata-sphinx-theme==0.15.2
-sphinx-copybutton==0.5.2
-myst-parser==2.0.0
-numpydoc==1.6.0
+sphinx==6.2.1
+sphinx-autodoc-typehints==1.23.0
+pydata-sphinx-theme==0.7.2
+sphinx-copybutton==0.5.0
+myst-parser==3.0.1
+numpydoc==1.5.0
 
 # Project dependencies needed for autodoc
 torch>=2.7.0


### PR DESCRIPTION
## Summary
- pin the Sphinx version in `.readthedocs.yaml`
- drop unused pip extras
- align `docs/requirements.txt` with pinned docs dependencies

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy .`
- `pytest tests/`

------
https://chatgpt.com/codex/tasks/task_e_6844df4f55b0832ba6a550fa3b29c4eb