### PR TITLE
Fix Read the Docs build configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,6 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
-    sphinx: "6.2.1"
   jobs:
     post_create_environment:
       # Install poetry
@@ -21,8 +20,6 @@ sphinx:
   configuration: docs/conf.py
   builder: html
   fail_on_warning: false  # Set to true after initial setup
-  version: "6.2.1"
-
 
 # Build PDF & ePub
 formats:


### PR DESCRIPTION
## Summary
Fixes Read the Docs build failure caused by invalid configuration entries.

## Changes
- Removed `sphinx` from `build.tools` section (not a valid tool type)
- Removed `version` from `sphinx` section (not a valid option)

## Details
Read the Docs only accepts specific tool types (`python`, `nodejs`, `ruby`, `rust`, `golang`) in the `build.tools` section. Sphinx is installed via Poetry dependencies, not as a build tool.

Fixes build error:
```
Config validation error in `build.tools`. Expected one of (python, nodejs, ruby, rust, golang), got type `str` (`sphinx`).
```

## Testing
The configuration has been validated against Read the Docs documentation. The build should pass after these changes.


------
https://chatgpt.com/codex/tasks/task_e_6844e568b710832bbc52dbd88d96e664