### PR TITLE
Fix RTD poetry venv conflict

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,6 @@ build:
       - pip install poetry
     post_install:
       # Install project dependencies
-      - poetry config virtualenvs.create false
       - poetry install --with docs --no-interaction
 
 # Sphinx configuration


### PR DESCRIPTION
## Summary
- remove Poetry config that disabled virtualenv creation

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy .`
- `pytest tests/`

------
https://chatgpt.com/codex/tasks/task_e_6844ea40a5dc832bb57569c32d42d5dd