### PR TITLE
Drop sphinx_autodoc_typehints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -455,7 +455,6 @@ extensions = [
     'sphinx.ext.napoleon',  # For NumPy-style docstrings
     'sphinx.ext.viewcode',
     'sphinx.ext.mathjax',   # For LaTeX math
-    'sphinx_autodoc_typehints',
 ]
 
 # Napoleon settings for NumPy style

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,8 +23,6 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
     "sphinx.ext.githubpages",
-    # Additional extensions
-    "sphinx_autodoc_typehints",
 ]
 
 # Optional extensions
@@ -87,10 +85,6 @@ napoleon_type_aliases = {
     "Dtype": "torch.dtype",
 }
 
-# Type hints
-typehints_defaults = "comma"
-typehints_use_signature = True
-typehints_use_signature_return = True
 
 # Intersphinx mapping (link to other projects)
 intersphinx_mapping = {

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,5 @@
 # Core dependencies needed for building docs
 sphinx==8.2.3
-sphinx-autodoc-typehints==3.2.0
 pydata-sphinx-theme==0.16.1
 sphinx-copybutton==0.5.2
 myst-parser==4.0.1

--- a/manifest.scm
+++ b/manifest.scm
@@ -32,7 +32,6 @@
    "python-tensorboard"
    "python-wandb"
    "python-sphinx"
-   "python-sphinx-autodoc-typehints"
    "python-pydata-sphinx-theme"
    "python-sphinx-copybutton"
    "python-myst-parser"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2267,23 +2267,6 @@ docs = ["sphinxcontrib-websupport"]
 lint = ["betterproto (==2.0.0b6)", "mypy (==1.15.0)", "pypi-attestations (==0.0.21)", "pyright (==1.1.395)", "pytest (>=8.0)", "ruff (==0.9.9)", "sphinx-lint (>=0.9)", "types-Pillow (==10.2.0.20240822)", "types-Pygments (==2.19.0.20250219)", "types-colorama (==0.4.15.20240311)", "types-defusedxml (==0.7.0.20240218)", "types-docutils (==0.21.0.20241128)", "types-requests (==2.32.0.20241016)", "types-urllib3 (==1.26.25.14)"]
 test = ["cython (>=3.0)", "defusedxml (>=0.7.1)", "pytest (>=8.0)", "pytest-xdist[psutil] (>=3.4)", "setuptools (>=70.0)", "typing_extensions (>=4.9)"]
 
-[[package]]
-name = "sphinx-autodoc-typehints"
-version = "3.2.0"
-description = "Type hints (PEP 484) support for the Sphinx autodoc extension"
-optional = false
-python-versions = ">=3.11"
-files = [
-    {file = "sphinx_autodoc_typehints-3.2.0-py3-none-any.whl", hash = "sha256:884b39be23b1d884dcc825d4680c9c6357a476936e3b381a67ae80091984eb49"},
-    {file = "sphinx_autodoc_typehints-3.2.0.tar.gz", hash = "sha256:107ac98bc8b4837202c88c0736d59d6da44076e65a0d7d7d543a78631f662a9b"},
-]
-
-[package.dependencies]
-sphinx = ">=8.2"
-
-[package.extras]
-docs = ["furo (>=2024.8.6)"]
-testing = ["covdefaults (>=2.3)", "coverage (>=7.6.12)", "defusedxml (>=0.7.1)", "diff-cover (>=9.2.3)", "pytest (>=8.3.4)", "pytest-cov (>=6)", "sphobjinv (>=2.3.1.2)", "typing-extensions (>=4.12.2)"]
 
 [[package]]
 name = "sphinx-copybutton"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ optional = true
 
 [tool.poetry.group.docs.dependencies]
 sphinx = "8.2.3"
-sphinx-autodoc-typehints = "3.2.0"
 pydata-sphinx-theme = "0.16.1"
 sphinx-copybutton = "0.5.2"
 myst-parser = "4.0.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,6 @@ pillow==11.1.0
 
 # Documentation dependencies
 sphinx==8.2.3
-sphinx-autodoc-typehints==3.2.0
 pydata-sphinx-theme==0.16.1
 sphinx-copybutton==0.5.2
 myst-parser==4.0.1


### PR DESCRIPTION
## Summary
- trim docs tooling
- remove heavy sphinx_autodoc_typehints extension and dependency

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy .`
- `pytest tests/ -q`

------
https://chatgpt.com/codex/tasks/task_e_6844f16db5a4832b877cb3da7404f1d9