### PR TITLE
Add housekeeping guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,11 +39,6 @@ git add -A && git commit -m "..."
 ### PyTorch First
 Follow PyTorch's conventions for everything - API design, naming, code organization. When in doubt, check how PyTorch core does it.
 
-## Coding Conventions
-
-### PyTorch First
-Follow PyTorch's conventions for everything - API design, naming, code organization. When in doubt, check how PyTorch core does it.
-
 ### Modern Python (3.11+)
 
 Use modern Python features for cleaner, more maintainable code:
@@ -864,3 +859,35 @@ pytest tests/ -k "attention" -v
 - Main paper: "Energy Transformer" (Hoover et al., 2023)
 - Issues: Check GitHub issues for known problems
 - Discussions: See GitHub discussions for design decisions
+
+## Housekeeping & Release Protocols
+
+### Commit Message Format
+- Use `component: short imperative summary`.
+- Keep lines under 72 characters.
+- Reference issues in parentheses, e.g. `optim: fix lr schedule (#123)`.
+
+### Commit Sequencing
+1. Run `ruff check --fix`, `ruff format`, `mypy`, and `pytest tests/` before each commit.
+2. Keep commits small and logically focused.
+3. Avoid mixing refactors with new features.
+
+### PR Message Format
+- **Title:** `[component] Summary`
+- **Body:**
+  - Overview of changes
+  - Testing details
+  - Note breaking changes or migrations
+
+### CHANGELOG Maintenance
+- Edit `CHANGELOG.md` under an **Unreleased** section for every PR.
+- Use `Added`, `Changed`, `Fixed`, `Removed` bullet lists and link PR numbers.
+
+### Release Process
+1. Bump `pyproject.toml`'s `version` field according to SemVer.
+2. Move `Unreleased` notes in `CHANGELOG.md` to a new version heading with the release date.
+3. Tag the release as `vX.Y.Z` and push the tag.
+
+### Regular Housekeeping
+- Remove stale TODOs and keep docs in sync with code.
+- Periodically run `ruff check . --select F401` to catch unused imports.


### PR DESCRIPTION
## Summary
- expand `AGENTS.md` with commit/PR guidelines
- document changelog and release workflow
- fix duplicate `Coding Conventions` heading

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy .`
- `pytest tests/ -q`


------
https://chatgpt.com/codex/tasks/task_e_68493bb80c08832b85ea40682d437698