### PR TITLE
[models] unify builder configs

### DIFF
--- a/energy_transformer/models/__init__.py
+++ b/energy_transformer/models/__init__.py
@@ -6,8 +6,9 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover
     from .base import EnergyTransformer
+    from .configs import ViETConfig, ViSETConfig, ViTConfig
 
-__all__ = ["EnergyTransformer"]
+__all__ = ["EnergyTransformer", "ViETConfig", "ViSETConfig", "ViTConfig"]
 
 
 def __getattr__(name: str) -> object:
@@ -32,5 +33,13 @@ def __getattr__(name: str) -> object:
         from .base import EnergyTransformer
 
         return EnergyTransformer
+    if name in {"ViTConfig", "ViETConfig", "ViSETConfig"}:
+        from .configs import ViETConfig, ViSETConfig, ViTConfig
+
+        return {
+            "ViTConfig": ViTConfig,
+            "ViETConfig": ViETConfig,
+            "ViSETConfig": ViSETConfig,
+        }[name]
     msg = f"module {__name__!r} has no attribute {name!r}"
     raise AttributeError(msg)

--- a/energy_transformer/models/configs.py
+++ b/energy_transformer/models/configs.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Self
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .vision.viet import VisionEnergyTransformer
+    from .vision.viset import VisionSimplicialTransformer
+    from .vision.vit import VisionTransformer
+
+
+@dataclass(slots=True)
+class ViTConfig:
+    """Configuration for :class:`VisionTransformer`."""
+
+    img_size: int = 224
+    patch_size: int = 16
+    in_chans: int = 3
+    num_classes: int = 1000
+    embed_dim: int = 768
+    depth: int = 12
+    num_heads: int = 12
+    mlp_ratio: float = 4.0
+    drop_rate: float = 0.0
+
+    def apply_overrides(self, **overrides: Any) -> Self:
+        for key, value in overrides.items():
+            if not hasattr(self, key):
+                msg = f"{self.__class__.__name__}: unknown field {key!r}"
+                raise TypeError(msg)
+            setattr(self, key, value)
+        return self
+
+    def build(self) -> "VisionTransformer":
+        from .vision.vit import VisionTransformer
+
+        return VisionTransformer(
+            img_size=self.img_size,
+            patch_size=self.patch_size,
+            in_chans=self.in_chans,
+            num_classes=self.num_classes,
+            embed_dim=self.embed_dim,
+            depth=self.depth,
+            num_heads=self.num_heads,
+            mlp_ratio=self.mlp_ratio,
+            drop_rate=self.drop_rate,
+        )
+
+
+@dataclass(slots=True)
+class ViETConfig:
+    """Configuration for :class:`VisionEnergyTransformer`."""
+
+    img_size: int = 224
+    patch_size: int = 16
+    in_chans: int = 3
+    num_classes: int = 1000
+    embed_dim: int = 768
+    depth: int = 12
+    num_heads: int = 12
+    hopfield_hidden_dim: int = 3072
+    et_steps: int = 4
+    drop_rate: float = 0.0
+
+    def apply_overrides(self, **overrides: Any) -> Self:
+        for key, value in overrides.items():
+            if not hasattr(self, key):
+                msg = f"{self.__class__.__name__}: unknown field {key!r}"
+                raise TypeError(msg)
+            setattr(self, key, value)
+        return self
+
+    def build(self) -> "VisionEnergyTransformer":
+        from .vision.viet import VisionEnergyTransformer
+
+        return VisionEnergyTransformer(
+            img_size=self.img_size,
+            patch_size=self.patch_size,
+            in_chans=self.in_chans,
+            num_classes=self.num_classes,
+            embed_dim=self.embed_dim,
+            depth=self.depth,
+            num_heads=self.num_heads,
+            hopfield_hidden_dim=self.hopfield_hidden_dim,
+            et_steps=self.et_steps,
+            drop_rate=self.drop_rate,
+        )
+
+
+@dataclass(slots=True)
+class ViSETConfig:
+    """Configuration for :class:`VisionSimplicialTransformer`."""
+
+    img_size: int = 224
+    patch_size: int = 16
+    in_chans: int = 3
+    num_classes: int = 1000
+    embed_dim: int = 768
+    depth: int = 12
+    num_heads: int = 12
+    hopfield_hidden_dim: int = 3072
+    et_steps: int = 4
+    drop_rate: float = 0.0
+    hopfield_beta: float = 0.1
+    triangle_fraction: float = 0.5
+
+    def apply_overrides(self, **overrides: Any) -> Self:
+        for key, value in overrides.items():
+            if not hasattr(self, key):
+                msg = f"{self.__class__.__name__}: unknown field {key!r}"
+                raise TypeError(msg)
+            setattr(self, key, value)
+        return self
+
+    def build(self) -> "VisionSimplicialTransformer":
+        from .vision.viset import VisionSimplicialTransformer
+
+        return VisionSimplicialTransformer(
+            img_size=self.img_size,
+            patch_size=self.patch_size,
+            in_chans=self.in_chans,
+            num_classes=self.num_classes,
+            embed_dim=self.embed_dim,
+            depth=self.depth,
+            num_heads=self.num_heads,
+            hopfield_hidden_dim=self.hopfield_hidden_dim,
+            et_steps=self.et_steps,
+            drop_rate=self.drop_rate,
+            hopfield_beta=self.hopfield_beta,
+            triangle_fraction=self.triangle_fraction,
+        )
+
+
+__all__ = ["ViETConfig", "ViSETConfig", "ViTConfig"]

--- a/energy_transformer/models/configs.py
+++ b/energy_transformer/models/configs.py
@@ -24,6 +24,7 @@ class ViTConfig:
     drop_rate: float = 0.0
 
     def apply_overrides(self, **overrides: Any) -> Self:
+        """Apply runtime overrides to this configuration."""
         for key, value in overrides.items():
             if not hasattr(self, key):
                 msg = f"{self.__class__.__name__}: unknown field {key!r}"
@@ -31,7 +32,8 @@ class ViTConfig:
             setattr(self, key, value)
         return self
 
-    def build(self) -> "VisionTransformer":
+    def build(self) -> VisionTransformer:
+        """Construct a :class:`VisionTransformer` from this configuration."""
         from .vision.vit import VisionTransformer
 
         return VisionTransformer(
@@ -63,6 +65,7 @@ class ViETConfig:
     drop_rate: float = 0.0
 
     def apply_overrides(self, **overrides: Any) -> Self:
+        """Apply runtime overrides to this configuration."""
         for key, value in overrides.items():
             if not hasattr(self, key):
                 msg = f"{self.__class__.__name__}: unknown field {key!r}"
@@ -70,7 +73,8 @@ class ViETConfig:
             setattr(self, key, value)
         return self
 
-    def build(self) -> "VisionEnergyTransformer":
+    def build(self) -> VisionEnergyTransformer:
+        """Construct a :class:`VisionEnergyTransformer` from this configuration."""
         from .vision.viet import VisionEnergyTransformer
 
         return VisionEnergyTransformer(
@@ -105,6 +109,7 @@ class ViSETConfig:
     triangle_fraction: float = 0.5
 
     def apply_overrides(self, **overrides: Any) -> Self:
+        """Apply runtime overrides to this configuration."""
         for key, value in overrides.items():
             if not hasattr(self, key):
                 msg = f"{self.__class__.__name__}: unknown field {key!r}"
@@ -112,7 +117,8 @@ class ViSETConfig:
             setattr(self, key, value)
         return self
 
-    def build(self) -> "VisionSimplicialTransformer":
+    def build(self) -> VisionSimplicialTransformer:
+        """Construct a :class:`VisionSimplicialTransformer` from this configuration."""
         from .vision.viset import VisionSimplicialTransformer
 
         return VisionSimplicialTransformer(

--- a/energy_transformer/models/vision/viet.py
+++ b/energy_transformer/models/vision/viet.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 from typing import Any, cast
 
+from ..configs import ViETConfig
+
 __all__ = [
     "VisionEnergyTransformer",
     "viet_2l_cifar",
@@ -221,58 +223,58 @@ class VisionEnergyTransformer(nn.Module):
 
 def viet_tiny(**kwargs: Any) -> VisionEnergyTransformer:
     """ViET-Tiny configuration."""
-    config: dict[str, Any] = {
-        "embed_dim": 192,
-        "depth": 12,
-        "num_heads": 3,
-        "hopfield_hidden_dim": 768,  # 4x embed_dim
-        "et_steps": 4,
-        "in_chans": 3,
-    }
-    config.update(kwargs)
-    return VisionEnergyTransformer(**config)
+    config = ViETConfig(
+        embed_dim=192,
+        depth=12,
+        num_heads=3,
+        hopfield_hidden_dim=768,
+        et_steps=4,
+        in_chans=3,
+    )
+    config.apply_overrides(**kwargs)
+    return config.build()
 
 
 def viet_small(**kwargs: Any) -> VisionEnergyTransformer:
     """ViET-Small configuration."""
-    config: dict[str, Any] = {
-        "embed_dim": 384,
-        "depth": 12,
-        "num_heads": 6,
-        "hopfield_hidden_dim": 1536,  # 4x embed_dim
-        "et_steps": 4,
-        "in_chans": 3,
-    }
-    config.update(kwargs)
-    return VisionEnergyTransformer(**config)
+    config = ViETConfig(
+        embed_dim=384,
+        depth=12,
+        num_heads=6,
+        hopfield_hidden_dim=1536,
+        et_steps=4,
+        in_chans=3,
+    )
+    config.apply_overrides(**kwargs)
+    return config.build()
 
 
 def viet_base(**kwargs: Any) -> VisionEnergyTransformer:
     """ViET-Base configuration."""
-    config: dict[str, Any] = {
-        "embed_dim": 768,
-        "depth": 12,
-        "num_heads": 12,
-        "hopfield_hidden_dim": 3072,  # 4x embed_dim
-        "et_steps": 4,
-        "in_chans": 3,
-    }
-    config.update(kwargs)
-    return VisionEnergyTransformer(**config)
+    config = ViETConfig(
+        embed_dim=768,
+        depth=12,
+        num_heads=12,
+        hopfield_hidden_dim=3072,
+        et_steps=4,
+        in_chans=3,
+    )
+    config.apply_overrides(**kwargs)
+    return config.build()
 
 
 def viet_large(**kwargs: Any) -> VisionEnergyTransformer:
     """ViET-Large configuration."""
-    config: dict[str, Any] = {
-        "embed_dim": 1024,
-        "depth": 24,
-        "num_heads": 16,
-        "hopfield_hidden_dim": 4096,  # 4x embed_dim
-        "et_steps": 4,
-        "in_chans": 3,
-    }
-    config.update(kwargs)
-    return VisionEnergyTransformer(**config)
+    config = ViETConfig(
+        embed_dim=1024,
+        depth=24,
+        num_heads=16,
+        hopfield_hidden_dim=4096,
+        et_steps=4,
+        in_chans=3,
+    )
+    config.apply_overrides(**kwargs)
+    return config.build()
 
 
 # CIFAR-specific configurations
@@ -283,20 +285,20 @@ def viet_tiny_cifar(
     **kwargs: Any,
 ) -> VisionEnergyTransformer:
     """ViET-Tiny for CIFAR datasets."""
-    config: dict[str, Any] = {
-        "img_size": 32,
-        "patch_size": 4,
-        "in_chans": 3,
-        "num_classes": num_classes,
-        "embed_dim": 192,
-        "depth": 12,
-        "num_heads": 3,
-        "hopfield_hidden_dim": 768,
-        "et_steps": 4,
-        "drop_rate": 0.1,
-    }
-    config.update(kwargs)
-    return VisionEnergyTransformer(**config)
+    config = ViETConfig(
+        img_size=32,
+        patch_size=4,
+        in_chans=3,
+        num_classes=num_classes,
+        embed_dim=192,
+        depth=12,
+        num_heads=3,
+        hopfield_hidden_dim=768,
+        et_steps=4,
+        drop_rate=0.1,
+    )
+    config.apply_overrides(**kwargs)
+    return config.build()
 
 
 def viet_small_cifar(
@@ -304,20 +306,20 @@ def viet_small_cifar(
     **kwargs: Any,
 ) -> VisionEnergyTransformer:
     """ViET-Small for CIFAR datasets."""
-    config: dict[str, Any] = {
-        "img_size": 32,
-        "patch_size": 4,
-        "in_chans": 3,
-        "num_classes": num_classes,
-        "embed_dim": 384,
-        "depth": 12,
-        "num_heads": 6,
-        "hopfield_hidden_dim": 1536,
-        "et_steps": 4,
-        "drop_rate": 0.1,
-    }
-    config.update(kwargs)
-    return VisionEnergyTransformer(**config)
+    config = ViETConfig(
+        img_size=32,
+        patch_size=4,
+        in_chans=3,
+        num_classes=num_classes,
+        embed_dim=384,
+        depth=12,
+        num_heads=6,
+        hopfield_hidden_dim=1536,
+        et_steps=4,
+        drop_rate=0.1,
+    )
+    config.apply_overrides(**kwargs)
+    return config.build()
 
 
 # Shallow CIFAR configurations for testing
@@ -328,20 +330,20 @@ def viet_2l_cifar(
     **kwargs: Any,
 ) -> VisionEnergyTransformer:
     """Vision Energy Transformer with only 2 layers for CIFAR datasets."""
-    config: dict[str, Any] = {
-        "img_size": 32,
-        "patch_size": 4,
-        "in_chans": 3,
-        "num_classes": num_classes,
-        "embed_dim": 192,
-        "depth": 2,  # Shallow!
-        "num_heads": 8,
-        "hopfield_hidden_dim": 576,  # 3x embed_dim
-        "et_steps": 6,
-        "drop_rate": 0.1,
-    }
-    config.update(kwargs)
-    return VisionEnergyTransformer(**config)
+    config = ViETConfig(
+        img_size=32,
+        patch_size=4,
+        in_chans=3,
+        num_classes=num_classes,
+        embed_dim=192,
+        depth=2,
+        num_heads=8,
+        hopfield_hidden_dim=576,
+        et_steps=6,
+        drop_rate=0.1,
+    )
+    config.apply_overrides(**kwargs)
+    return config.build()
 
 
 def viet_4l_cifar(
@@ -349,20 +351,20 @@ def viet_4l_cifar(
     **kwargs: Any,
 ) -> VisionEnergyTransformer:
     """Vision Energy Transformer with 4 layers for CIFAR datasets."""
-    config: dict[str, Any] = {
-        "img_size": 32,
-        "patch_size": 4,
-        "in_chans": 3,
-        "num_classes": num_classes,
-        "embed_dim": 192,
-        "depth": 4,
-        "num_heads": 8,
-        "hopfield_hidden_dim": 576,
-        "et_steps": 5,
-        "drop_rate": 0.1,
-    }
-    config.update(kwargs)
-    return VisionEnergyTransformer(**config)
+    config = ViETConfig(
+        img_size=32,
+        patch_size=4,
+        in_chans=3,
+        num_classes=num_classes,
+        embed_dim=192,
+        depth=4,
+        num_heads=8,
+        hopfield_hidden_dim=576,
+        et_steps=5,
+        drop_rate=0.1,
+    )
+    config.apply_overrides(**kwargs)
+    return config.build()
 
 
 def viet_6l_cifar(
@@ -370,17 +372,17 @@ def viet_6l_cifar(
     **kwargs: Any,
 ) -> VisionEnergyTransformer:
     """Vision Energy Transformer with 6 layers for CIFAR datasets."""
-    config: dict[str, Any] = {
-        "img_size": 32,
-        "patch_size": 4,
-        "in_chans": 3,
-        "num_classes": num_classes,
-        "embed_dim": 192,
-        "depth": 6,
-        "num_heads": 8,
-        "hopfield_hidden_dim": 576,
-        "et_steps": 4,
-        "drop_rate": 0.1,
-    }
-    config.update(kwargs)
-    return VisionEnergyTransformer(**config)
+    config = ViETConfig(
+        img_size=32,
+        patch_size=4,
+        in_chans=3,
+        num_classes=num_classes,
+        embed_dim=192,
+        depth=6,
+        num_heads=8,
+        hopfield_hidden_dim=576,
+        et_steps=4,
+        drop_rate=0.1,
+    )
+    config.apply_overrides(**kwargs)
+    return config.build()

--- a/energy_transformer/models/vision/viet.py
+++ b/energy_transformer/models/vision/viet.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from typing import Any, cast
 
-from ..configs import ViETConfig
+from energy_transformer.models.configs import ViETConfig
 
 __all__ = [
     "VisionEnergyTransformer",

--- a/energy_transformer/models/vision/viset.py
+++ b/energy_transformer/models/vision/viset.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, cast
 
-from ..configs import ViSETConfig
+from energy_transformer.models.configs import ViSETConfig
 
 __all__ = [
     "VisionSimplicialTransformer",

--- a/energy_transformer/models/vision/viset.py
+++ b/energy_transformer/models/vision/viset.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any, cast
 
+from ..configs import ViSETConfig
+
 __all__ = [
     "VisionSimplicialTransformer",
     "viset_2l_cifar",
@@ -171,164 +173,164 @@ class VisionSimplicialTransformer(nn.Module):
 
 def viset_tiny(**kwargs: Any) -> VisionSimplicialTransformer:
     """ViSET-Tiny configuration."""
-    config: dict[str, Any] = {
-        "embed_dim": 192,
-        "depth": 12,
-        "num_heads": 3,
-        "hopfield_hidden_dim": 768,
-        "et_steps": 4,
-        "in_chans": 3,
-        "triangle_fraction": 0.5,
-    }
-    config.update(kwargs)
-    return VisionSimplicialTransformer(**config)
+    config = ViSETConfig(
+        embed_dim=192,
+        depth=12,
+        num_heads=3,
+        hopfield_hidden_dim=768,
+        et_steps=4,
+        in_chans=3,
+        triangle_fraction=0.5,
+    )
+    config.apply_overrides(**kwargs)
+    return config.build()
 
 
 def viset_small(**kwargs: Any) -> VisionSimplicialTransformer:
     """ViSET-Small configuration."""
-    config: dict[str, Any] = {
-        "embed_dim": 384,
-        "depth": 12,
-        "num_heads": 6,
-        "hopfield_hidden_dim": 1536,
-        "et_steps": 4,
-        "in_chans": 3,
-        "triangle_fraction": 0.5,
-    }
-    config.update(kwargs)
-    return VisionSimplicialTransformer(**config)
+    config = ViSETConfig(
+        embed_dim=384,
+        depth=12,
+        num_heads=6,
+        hopfield_hidden_dim=1536,
+        et_steps=4,
+        in_chans=3,
+        triangle_fraction=0.5,
+    )
+    config.apply_overrides(**kwargs)
+    return config.build()
 
 
 def viset_base(**kwargs: Any) -> VisionSimplicialTransformer:
     """ViSET-Base configuration."""
-    config: dict[str, Any] = {
-        "embed_dim": 768,
-        "depth": 12,
-        "num_heads": 12,
-        "hopfield_hidden_dim": 3072,
-        "et_steps": 4,
-        "in_chans": 3,
-        "triangle_fraction": 0.5,
-    }
-    config.update(kwargs)
-    return VisionSimplicialTransformer(**config)
+    config = ViSETConfig(
+        embed_dim=768,
+        depth=12,
+        num_heads=12,
+        hopfield_hidden_dim=3072,
+        et_steps=4,
+        in_chans=3,
+        triangle_fraction=0.5,
+    )
+    config.apply_overrides(**kwargs)
+    return config.build()
 
 
 def viset_large(**kwargs: Any) -> VisionSimplicialTransformer:
     """ViSET-Large configuration."""
-    config: dict[str, Any] = {
-        "embed_dim": 1024,
-        "depth": 24,
-        "num_heads": 16,
-        "hopfield_hidden_dim": 4096,
-        "et_steps": 4,
-        "in_chans": 3,
-        "triangle_fraction": 0.5,
-    }
-    config.update(kwargs)
-    return VisionSimplicialTransformer(**config)
+    config = ViSETConfig(
+        embed_dim=1024,
+        depth=24,
+        num_heads=16,
+        hopfield_hidden_dim=4096,
+        et_steps=4,
+        in_chans=3,
+        triangle_fraction=0.5,
+    )
+    config.apply_overrides(**kwargs)
+    return config.build()
 
 
 def viset_tiny_cifar(
     num_classes: int = 100, **kwargs: Any
 ) -> VisionSimplicialTransformer:
     """ViSET-Tiny for CIFAR datasets."""
-    config: dict[str, Any] = {
-        "img_size": 32,
-        "patch_size": 4,
-        "in_chans": 3,
-        "num_classes": num_classes,
-        "embed_dim": 192,
-        "depth": 12,
-        "num_heads": 3,
-        "hopfield_hidden_dim": 768,
-        "et_steps": 4,
-        "drop_rate": 0.1,
-        "triangle_fraction": 0.5,
-    }
-    config.update(kwargs)
-    return VisionSimplicialTransformer(**config)
+    config = ViSETConfig(
+        img_size=32,
+        patch_size=4,
+        in_chans=3,
+        num_classes=num_classes,
+        embed_dim=192,
+        depth=12,
+        num_heads=3,
+        hopfield_hidden_dim=768,
+        et_steps=4,
+        drop_rate=0.1,
+        triangle_fraction=0.5,
+    )
+    config.apply_overrides(**kwargs)
+    return config.build()
 
 
 def viset_small_cifar(
     num_classes: int = 100, **kwargs: Any
 ) -> VisionSimplicialTransformer:
     """ViSET-Small for CIFAR datasets."""
-    config: dict[str, Any] = {
-        "img_size": 32,
-        "patch_size": 4,
-        "in_chans": 3,
-        "num_classes": num_classes,
-        "embed_dim": 384,
-        "depth": 12,
-        "num_heads": 6,
-        "hopfield_hidden_dim": 1536,
-        "et_steps": 4,
-        "drop_rate": 0.1,
-        "triangle_fraction": 0.5,
-    }
-    config.update(kwargs)
-    return VisionSimplicialTransformer(**config)
+    config = ViSETConfig(
+        img_size=32,
+        patch_size=4,
+        in_chans=3,
+        num_classes=num_classes,
+        embed_dim=384,
+        depth=12,
+        num_heads=6,
+        hopfield_hidden_dim=1536,
+        et_steps=4,
+        drop_rate=0.1,
+        triangle_fraction=0.5,
+    )
+    config.apply_overrides(**kwargs)
+    return config.build()
 
 
 def viset_2l_cifar(
     num_classes: int = 100, **kwargs: Any
 ) -> VisionSimplicialTransformer:
     """2-layer ViSET for CIFAR datasets."""
-    config: dict[str, Any] = {
-        "img_size": 32,
-        "patch_size": 4,
-        "in_chans": 3,
-        "num_classes": num_classes,
-        "embed_dim": 192,
-        "depth": 2,
-        "num_heads": 8,
-        "hopfield_hidden_dim": 192,
-        "et_steps": 6,
-        "drop_rate": 0.1,
-        "triangle_fraction": 0.5,
-    }
-    config.update(kwargs)
-    return VisionSimplicialTransformer(**config)
+    config = ViSETConfig(
+        img_size=32,
+        patch_size=4,
+        in_chans=3,
+        num_classes=num_classes,
+        embed_dim=192,
+        depth=2,
+        num_heads=8,
+        hopfield_hidden_dim=192,
+        et_steps=6,
+        drop_rate=0.1,
+        triangle_fraction=0.5,
+    )
+    config.apply_overrides(**kwargs)
+    return config.build()
 
 
 def viset_4l_cifar(
     num_classes: int = 100, **kwargs: Any
 ) -> VisionSimplicialTransformer:
     """4-layer ViSET for CIFAR datasets."""
-    config: dict[str, Any] = {
-        "img_size": 32,
-        "patch_size": 4,
-        "in_chans": 3,
-        "num_classes": num_classes,
-        "embed_dim": 192,
-        "depth": 4,
-        "num_heads": 8,
-        "hopfield_hidden_dim": 192,
-        "et_steps": 5,
-        "drop_rate": 0.1,
-        "triangle_fraction": 0.5,
-    }
-    config.update(kwargs)
-    return VisionSimplicialTransformer(**config)
+    config = ViSETConfig(
+        img_size=32,
+        patch_size=4,
+        in_chans=3,
+        num_classes=num_classes,
+        embed_dim=192,
+        depth=4,
+        num_heads=8,
+        hopfield_hidden_dim=192,
+        et_steps=5,
+        drop_rate=0.1,
+        triangle_fraction=0.5,
+    )
+    config.apply_overrides(**kwargs)
+    return config.build()
 
 
 def viset_6l_cifar(
     num_classes: int = 100, **kwargs: Any
 ) -> VisionSimplicialTransformer:
     """6-layer ViSET for CIFAR datasets."""
-    config: dict[str, Any] = {
-        "img_size": 32,
-        "patch_size": 4,
-        "in_chans": 3,
-        "num_classes": num_classes,
-        "embed_dim": 192,
-        "depth": 6,
-        "num_heads": 8,
-        "hopfield_hidden_dim": 192,
-        "et_steps": 4,
-        "drop_rate": 0.1,
-        "triangle_fraction": 0.5,
-    }
-    config.update(kwargs)
-    return VisionSimplicialTransformer(**config)
+    config = ViSETConfig(
+        img_size=32,
+        patch_size=4,
+        in_chans=3,
+        num_classes=num_classes,
+        embed_dim=192,
+        depth=6,
+        num_heads=8,
+        hopfield_hidden_dim=192,
+        et_steps=4,
+        drop_rate=0.1,
+        triangle_fraction=0.5,
+    )
+    config.apply_overrides(**kwargs)
+    return config.build()

--- a/energy_transformer/models/vision/vit.py
+++ b/energy_transformer/models/vision/vit.py
@@ -50,7 +50,7 @@ from __future__ import annotations
 
 from typing import Any, cast
 
-from ..configs import ViTConfig
+from energy_transformer.models.configs import ViTConfig
 
 __all__ = [
     "PatchEmbedding",

--- a/energy_transformer/models/vision/vit.py
+++ b/energy_transformer/models/vision/vit.py
@@ -50,6 +50,8 @@ from __future__ import annotations
 
 from typing import Any, cast
 
+from ..configs import ViTConfig
+
 __all__ = [
     "PatchEmbedding",
     "VisionTransformer",
@@ -383,54 +385,54 @@ class MLP(nn.Module):
 
 def vit_tiny(**kwargs: Any) -> VisionTransformer:
     """ViT-Tiny configuration."""
-    config: dict[str, Any] = {
-        "embed_dim": 192,
-        "depth": 12,
-        "num_heads": 3,
-        "mlp_ratio": 4.0,
-        "in_chans": 3,
-    }
-    config.update(kwargs)
-    return VisionTransformer(**config)
+    config = ViTConfig(
+        embed_dim=192,
+        depth=12,
+        num_heads=3,
+        mlp_ratio=4.0,
+        in_chans=3,
+    )
+    config.apply_overrides(**kwargs)
+    return config.build()
 
 
 def vit_small(**kwargs: Any) -> VisionTransformer:
     """ViT-Small configuration."""
-    config: dict[str, Any] = {
-        "embed_dim": 384,
-        "depth": 12,
-        "num_heads": 6,
-        "mlp_ratio": 4.0,
-        "in_chans": 3,
-    }
-    config.update(kwargs)
-    return VisionTransformer(**config)
+    config = ViTConfig(
+        embed_dim=384,
+        depth=12,
+        num_heads=6,
+        mlp_ratio=4.0,
+        in_chans=3,
+    )
+    config.apply_overrides(**kwargs)
+    return config.build()
 
 
 def vit_base(**kwargs: Any) -> VisionTransformer:
     """ViT-Base configuration."""
-    config: dict[str, Any] = {
-        "embed_dim": 768,
-        "depth": 12,
-        "num_heads": 12,
-        "mlp_ratio": 4.0,
-        "in_chans": 3,
-    }
-    config.update(kwargs)
-    return VisionTransformer(**config)
+    config = ViTConfig(
+        embed_dim=768,
+        depth=12,
+        num_heads=12,
+        mlp_ratio=4.0,
+        in_chans=3,
+    )
+    config.apply_overrides(**kwargs)
+    return config.build()
 
 
 def vit_large(**kwargs: Any) -> VisionTransformer:
     """ViT-Large configuration."""
-    config: dict[str, Any] = {
-        "embed_dim": 1024,
-        "depth": 24,
-        "num_heads": 16,
-        "mlp_ratio": 4.0,
-        "in_chans": 3,
-    }
-    config.update(kwargs)
-    return VisionTransformer(**config)
+    config = ViTConfig(
+        embed_dim=1024,
+        depth=24,
+        num_heads=16,
+        mlp_ratio=4.0,
+        in_chans=3,
+    )
+    config.apply_overrides(**kwargs)
+    return config.build()
 
 
 # CIFAR-specific configurations
@@ -438,33 +440,33 @@ def vit_large(**kwargs: Any) -> VisionTransformer:
 
 def vit_tiny_cifar(num_classes: int = 100, **kwargs: Any) -> VisionTransformer:
     """ViT-Tiny for CIFAR datasets."""
-    config: dict[str, Any] = {
-        "img_size": 32,
-        "patch_size": 4,
-        "in_chans": 3,
-        "num_classes": num_classes,
-        "embed_dim": 192,
-        "depth": 12,
-        "num_heads": 3,
-        "mlp_ratio": 4.0,
-        "drop_rate": 0.1,
-    }
-    config.update(kwargs)
-    return VisionTransformer(**config)
+    config = ViTConfig(
+        img_size=32,
+        patch_size=4,
+        in_chans=3,
+        num_classes=num_classes,
+        embed_dim=192,
+        depth=12,
+        num_heads=3,
+        mlp_ratio=4.0,
+        drop_rate=0.1,
+    )
+    config.apply_overrides(**kwargs)
+    return config.build()
 
 
 def vit_small_cifar(num_classes: int = 100, **kwargs: Any) -> VisionTransformer:
     """ViT-Small for CIFAR datasets."""
-    config: dict[str, Any] = {
-        "img_size": 32,
-        "patch_size": 4,
-        "in_chans": 3,
-        "num_classes": num_classes,
-        "embed_dim": 384,
-        "depth": 12,
-        "num_heads": 6,
-        "mlp_ratio": 4.0,
-        "drop_rate": 0.1,
-    }
-    config.update(kwargs)
-    return VisionTransformer(**config)
+    config = ViTConfig(
+        img_size=32,
+        patch_size=4,
+        in_chans=3,
+        num_classes=num_classes,
+        embed_dim=384,
+        depth=12,
+        num_heads=6,
+        mlp_ratio=4.0,
+        drop_rate=0.1,
+    )
+    config.apply_overrides(**kwargs)
+    return config.build()


### PR DESCRIPTION
## Summary
- add `configs` module with dataclass configurations
- refactor ViT/ViET/ViSET factories to use shared configs
- export config classes from models package

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy .`
- `pytest tests/`

------
https://chatgpt.com/codex/tasks/task_e_684f09f8f8ac832b90915a255a372919